### PR TITLE
add optional init flag to collect Torch Export node-to-module mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Full support for PyTorch's negative indexing and complex operations:
 
 | Name        | Task        | Colab Link                          | HTML Link                                       |
 |-------------|-------------|-------------------------------| -------------------------------|
-| Custom Tabular Model | Binary Classification | [Colab Link](https://colab.research.google.com/drive/1TqgeeBqQ1G9UGWfHV0MUloCccalpsRCh?usp=sharing)| [HTML Version]() |
+| Custom Tabular Model | Binary Classification | [Colab Link](https://colab.research.google.com/drive/13N2sfAxA_7GJsZ7VAKS5WIOg6GusQghI?usp=sharing)| [HTML Version](https://drive.google.com/file/d/1_5DZWIe0Q5eB4CtVhkbO4zTCRbe6yW5D/view?usp=sharing) |
 | VGG Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1LxSazvy1Y2i0Ho1Qw7K905aNmvh66GzR?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1AO7cBJ9o6-Xtaqnall8HWG9ZccwtY-QZ/view?usp=sharing) |
 | ResNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1O8Is0X-IrKxXzgJeR1Xxy21OOR-UGfm7?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1tU573KFG2HPwM0bhFnGSueSc1uYm1ZCb/view?usp=sharing) |
 | ViT Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1B1xN5w51-tRnHyycbHV6lxi0tKxONnoS?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1E59Jlsv-v65V4qRL1q0xb0f5gmIsgPeg/view?usp=sharing) |

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ DLB v2 introduces **major architectural upgrades** to the explainability engine 
 
 | Metric | DLB v1 | DLB v2 | Improvement |
 |:-------|:-------|:-------|:-------------|
-| ⏱️ **Explainability Time** | Up to 29,000 s | 🕒 20 s | 🔥 **1000× faster** |
-| 🚀 **Throughput** | ~0.03 tokens/s | 🧩 75 tokens/s | ⚡ **2000× higher** |
-| 📈 **Scalability** | Degrades sharply | Scales linearly | ✅ **Stable & predictable** |
+| ⏱️ **Explainability Time** | 250–30,000 s (grows exponentially) | 🕒 12–18 s (nearly constant) | 🔥 **20× → 1400× faster** depending on sequence length |
+| 🚀 **Throughput** | ~0.01–0.03 tokens/s | 🧩 3–75 tokens/s | ⚡ **100× → 2500× higher** |
+| 📈 **Scalability** | Time increases ~8× every doubling | Grows slowly with input size | ✅ **Stable & linear-like scaling** |
 
 ---
 
@@ -71,7 +71,7 @@ DLB v2 introduces **major architectural upgrades** to the explainability engine 
 
 ---
 
-> 💡 **DLB v2** achieves up to **1000× speedup** using fused GPU kernels.
+> 💡 **DLB v2** provides **consistent low latency** and achieves **20×–1400× speedup** over DLB v1 as sequence length increases. 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -303,23 +303,23 @@ Full support for PyTorch's negative indexing and complex operations:
 
 ## Example Notebooks
 
-| Name        | Task        | Link                          |
-|-------------|-------------|-------------------------------|
-| Custom Tabular Model | Binary Classification | [Colab Link](https://colab.research.google.com/drive/1TqgeeBqQ1G9UGWfHV0MUloCccalpsRCh?usp=sharing)|
-| VGG Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1iJJZ0ApWHltTjnbGRKhJDrHlKTlm1koD?usp=sharing) |
-| ResNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1mpo--AD8vNqm6Y05rb46Yzjx6VhLwXZh?usp=sharing) |
-| ViT Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1BhzIw7Pf9-g1tqndaijwZ5FLaDUpjBaR?usp=sharing) |
-| DenseNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1CE2XBBGd5VSQuipJTyyRcb7mu5RSG6K5?usp=sharing) |
-| EfficientNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1O-MyvIKWoADG2RrF43p2k8mUYpF9N_8m?usp=sharing) |
-| MobileNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1BzsID9U3HndLrh67nPWRw_bm7UWLwLOH?usp=sharing) |
-| BERT-Base Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1ANZPjaAxl2oF2WHj23f87AR9-ZDIMBm9?usp=sharing) |
-| ALBERT Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1RuAW0FgtWqKkdVbc97VXf9z4oDXmA1ms?usp=sharing) |
-| RoBERTa Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1Nw6lTSQKJvGU9JBZeXnA7EXboU7mE282?usp=sharing) |
-| DistilBERT Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/13_hqUC2vaJWfF-UheggHJU5RmWS5A2u3?usp=sharing) |
-| Electra Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1sht3uLej8g-4hMtaHm7VwwUuGAmAqpH_?usp=sharing) |
-| XLNeT Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1ZmVusCPgeXLGnbt7NzM-3SJuiGRgTzBa?usp=sharing) |
-| LLaMA-3.2-1B Model | Text Generation | [Colab Link](https://colab.research.google.com/drive/1i_CKoCfKdY4fcWyFdzuc_0e868jux12h?usp=sharing) |
-| LLaMA-3.2-3B Model | Text Generation | [Colab Link](https://colab.research.google.com/drive/1ki8kcc4ez8-kdvdlhtoq7Sed9v5hiaNs?usp=sharing) |
+| Name        | Task        | Colab Link                          | HTML Link                                       |
+|-------------|-------------|-------------------------------| -------------------------------|
+| Custom Tabular Model | Binary Classification | [Colab Link](https://colab.research.google.com/drive/1TqgeeBqQ1G9UGWfHV0MUloCccalpsRCh?usp=sharing)| [HTML Version]() |
+| VGG Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1LxSazvy1Y2i0Ho1Qw7K905aNmvh66GzR?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1AO7cBJ9o6-Xtaqnall8HWG9ZccwtY-QZ/view?usp=sharing) |
+| ResNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1O8Is0X-IrKxXzgJeR1Xxy21OOR-UGfm7?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1tU573KFG2HPwM0bhFnGSueSc1uYm1ZCb/view?usp=sharing) |
+| ViT Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1B1xN5w51-tRnHyycbHV6lxi0tKxONnoS?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1E59Jlsv-v65V4qRL1q0xb0f5gmIsgPeg/view?usp=sharing) |
+| DenseNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1TspNRXd-qf81iZepUpU_TrUokZynynbu?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1B-6YwaA97ZVk693bQVukRZjVmZeaJt5Z/view?usp=sharing) |
+| EfficientNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/1Xv9ghxp0OXcfYOseoq37KiJbz-UkLvWq?usp=sharing) | [HTML Version](https://drive.google.com/file/d/19sl0_U9VZbFooX21osmKj35lwHNI6_uz/view?usp=sharing) |
+| MobileNet Model | Multi-Class Classification | [Colab Link](https://colab.research.google.com/drive/12D6NgYTf4Gud3BXLRfnUK1m5-RLZY6dv?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1Bi01z-_9Gejy7_eA7MsA6-fk9JTRfOQs/view?usp=sharing) |
+| BERT-Base Model | Sentiment Classification | [Colab Link](https://colab.research.google.com/drive/1eBAQ8TToJUs6EN4-md08cjfZUmAArX0s?usp=drive_link) | [HTML Version](https://drive.google.com/file/d/11YmWQ4KtztAk8TEIwFU3kajtM-VLc2O_/view?usp=sharing) |
+| LLaMA-3.2-1B Model | Text Generation | [Colab Link](https://colab.research.google.com/drive/1eZUK-PwI6iZeKnfcQHxIXO7xo8wYDEek?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1QJMWMcxD5ifS8ygoySXgFo9OxhXZTgVY/view?usp=sharing) |
+| Qwen-3-0.6B Model | Text Generation | [Colab Link](https://colab.research.google.com/drive/1nJsxk7HPhiZ1DUIXn0eOnu0yjye-WOQT?usp=drive_link) | [HTML Version](https://drive.google.com/file/d/1yBqe34IExmfD-YYZF_U3wuOK8JiEBDM2/view?usp=sharing) |
+| JetMoE | Text Generation | [Colab Link](https://colab.research.google.com/drive/1MKxR60Mf1F_TNMuE31T3GRWHFPTm5IhP?usp=drive_link) | [HTML Version](https://drive.google.com/file/d/1z39LZVa88YCFKgQPTXKgZIVoav7t1PBH/view?usp=sharing) |
+| OLMoE | Text Generation | [Colab Link](https://colab.research.google.com/drive/1e13QAFw4A8jKhZVb1jh-C_16A2u1vZIH?usp=drive_link) | [HTML Version](https://drive.google.com/file/d/1cHByb9EcR-7k2BAL-HmbprNS5oiL2k8q/view?usp=sharing) |
+| Qwen-3-MoE | Text Generation | [Colab Link](https://colab.research.google.com/drive/1ja26JGNt22rOMT0HCyjOMASXxfnMpkm8?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1Upk1l-SnDGT_Mw3Bm6mNmdAVWWYpyW-S/view?usp=sharing) |
+| GPT-Oss | Text Generation | [Colab Link](https://colab.research.google.com/drive/1zZXTOV4NOrauNDXjjYB8rausbBGoLYtX?usp=sharing) | [HTML Version](https://drive.google.com/file/d/1zs_XyjqmKiT-W3YEqFFTqEKL7z0N_bXq/view?usp=sharing) |
+
 
 For more detailed examples and use cases, check out our documentation.
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
@@ -1,5 +1,4 @@
 from .visualization import visualize_relevance
-from copy import deepcopy
 
 
 def attach_module_metadata(graph, fx_node_to_module):
@@ -37,7 +36,7 @@ def visualize_relevance_with_modules(
     but extends node labels with module information.
     """
     # Work on a copy to avoid side effects
-    graph = deepcopy(graph)
+    graph = graph.copy()
 
     # Attach metadata
     attach_module_metadata(graph, fx_node_to_module)

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
@@ -1,0 +1,60 @@
+from .visualization import visualize_relevance
+from copy import deepcopy
+
+
+def attach_module_metadata(graph, fx_node_to_module):
+    """
+    Attach module path/class metadata to graph nodes.
+
+    This function is purely additive and does not
+    modify graph structure.
+    """
+    if not fx_node_to_module:
+        return graph
+
+    for node in graph.nodes:
+        if node in fx_node_to_module:
+            module_path, module_class = fx_node_to_module[node]
+            graph.nodes[node]["module_path"] = module_path
+            graph.nodes[node]["module_class"] = module_class
+
+    return graph
+
+
+def visualize_relevance_with_modules(
+    graph,
+    all_wt,
+    fx_node_to_module,
+    output_path="backtrace_graph_modules",
+    *,
+    show=True,
+    inline_format="svg",
+):
+    """
+    Module-aware relevance visualization.
+
+    Uses the existing visualize_relevance logic,
+    but extends node labels with module information.
+    """
+    # Work on a copy to avoid side effects
+    graph = deepcopy(graph)
+
+    # Attach metadata
+    attach_module_metadata(graph, fx_node_to_module)
+
+    # Monkey-free label extension via node attributes
+    for n in graph.nodes:
+        mod = graph.nodes[n].get("module_path")
+        if mod:
+            graph.nodes[n]["_module_suffix"] = f"\n[{mod}]"
+        else:
+            graph.nodes[n]["_module_suffix"] = ""
+
+    # Call existing visualization
+    return visualize_relevance(
+        graph,
+        all_wt,
+        output_path=output_path,
+        show=show,
+        inline_format=inline_format,
+    )

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/visualization_module_aware.py
@@ -1,4 +1,5 @@
-from .visualization import visualize_relevance
+import graphviz
+from IPython.display import display, SVG, Image as IPyImage
 
 
 def attach_module_metadata(graph, fx_node_to_module):
@@ -20,7 +21,7 @@ def attach_module_metadata(graph, fx_node_to_module):
     return graph
 
 
-def visualize_relevance_with_modules(
+def visualize_relevance_with_module_labels(
     graph,
     all_wt,
     fx_node_to_module,
@@ -30,30 +31,87 @@ def visualize_relevance_with_modules(
     inline_format="svg",
 ):
     """
-    Module-aware relevance visualization.
-
-    Uses the existing visualize_relevance logic,
-    but extends node labels with module information.
+    Full replacement visualization that preserves the original graph
+    but injects module-path information into node labels.
     """
-    # Work on a copy to avoid side effects
-    graph = graph.copy()
+    # 1. Shallow copy the graph to avoid modifying the original
+    gcopy = graph.copy()
 
-    # Attach metadata
-    attach_module_metadata(graph, fx_node_to_module)
+    # 2. Attach module metadata
+    attach_module_metadata(gcopy, fx_node_to_module)
 
-    # Monkey-free label extension via node attributes
-    for n in graph.nodes:
-        mod = graph.nodes[n].get("module_path")
-        if mod:
-            graph.nodes[n]["_module_suffix"] = f"\n[{mod}]"
+    # 3. Extract relevance stats
+    relevance_data = {}
+    for node_name, rel in all_wt.items():
+        node_key = node_name.replace("/", " ").replace(":", " ")
+        if hasattr(rel, "mean"):
+            stats = (float(rel.mean()), float(rel.max()), float(rel.min()))
         else:
-            graph.nodes[n]["_module_suffix"] = ""
+            try:
+                val = float(rel)
+                stats = (val, val, val)
+            except:
+                stats = (0.0, 0.0, 0.0)
+        relevance_data[node_key] = stats
 
-    # Call existing visualization
-    return visualize_relevance(
-        graph,
-        all_wt,
-        output_path=output_path,
-        show=show,
-        inline_format=inline_format,
+    # 4. Build Graphviz digraph (similar to visualize_relevance, but modified)
+    g = graphviz.Digraph(
+        "DLBacktraceModules",
+        format="svg",
+        graph_attr={"rankdir": "LR", "splines": "spline"},
+        node_attr={"fontname": "Helvetica", "fontsize": "10"}
     )
+
+    # Color map reused from original
+    color_map = {
+        "MLP_Layer": "lightblue",
+        "DL_Layer": "lightgreen",
+        "Activation": "orange",
+        "Normalization": "pink",
+        "Mathematical_Operation": "yellow",
+        "Vector_Operation": "gray",
+        "Indexing_Operation": "lightgray",
+        "ATen_Operation": "violet",
+        "NLP_Embedding": "lightsalmon",
+        "Attention": "gold",
+        "Output": "red",
+        "Placeholder": "white",
+        "Model_Input": "lightcyan",
+    }
+
+    # 5. Add nodes (THIS IS WHERE MODULE LABELS ARE ADDED)
+    for node in gcopy.nodes:
+        name = node.replace("/", " ").replace(":", " ")
+        rel = relevance_data.get(name, (0.0, 0.0, 0.0))
+
+        # Pull module info
+        module_path = gcopy.nodes[node].get("module_path")
+        module_label = f"\n[{module_path}]" if module_path else ""
+
+        fill = color_map.get(gcopy.nodes[node].get("layer_type", "Unknown"), "white")
+
+        label = (
+            f"{name}{module_label}\n"
+            f"Mean: {rel[0]:.3f}\n"
+            f"Max: {rel[1]:.3f}\n"
+            f"Min: {rel[2]:.3f}"
+        )
+
+        g.node(name, label=label, style="filled", fillcolor=fill)
+
+    # 6. Add edges
+    for node in gcopy.nodes:
+        child = node.replace("/", " ").replace(":", " ")
+        for parent in gcopy.nodes[node].get("parents", []):
+            parent_norm = parent.replace("/", " ").replace(":", " ")
+            g.edge(parent_norm, child)
+
+    # 7. Render & show
+    out = g.render(output_path, cleanup=True)
+
+    if show:
+        svg_bytes = g.pipe(format="svg") if inline_format == "svg" else g.pipe(format="png")
+        display(SVG(svg_bytes) if inline_format == "svg" else IPyImage(data=svg_bytes))
+
+    print(f"📌 Module-aware relevance graph saved → {output_path}.svg")
+    return g, out

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -21,7 +21,7 @@ import torch
 import inspect
 
 class DLBacktrace:
-    def __init__(self, model, input_for_graph, dynamic_shapes=None, device="cpu", verbose=False, strict_cpu=True):
+    def __init__(self, model, input_for_graph, dynamic_shapes=None, device="cpu", verbose=False, strict_cpu=True, collect_node_module_map=False,):
         """
         Initialize DL-Backtrace FX for model tracing and explainability.
         
@@ -100,6 +100,14 @@ class DLBacktrace:
             print("---------------------------v6------------------------------------------", flush=True)
             print("🔧 Building computation graph...", flush=True)
 
+        # Optional: FX node → module mapping
+        self.fx_node_to_module = None
+        if collect_node_module_map:
+            if self.verbose:
+                print("🔧 Mapping FX nodes to nn.Module hierarchy...", flush=True)
+
+            self.fx_node_to_module = self.map_fx_nodes_to_modules()
+
         # Graph + metadata
         self.graph, self.layer_stack = build_graph(
             self.tracer, self.extracted_weights
@@ -113,6 +121,28 @@ class DLBacktrace:
         if self.verbose:
             print("---------------------------v8------------------------------------------", flush=True)
             print("✅ DL-Backtrace FX initialization complete!", flush=True)
+
+    def map_fx_nodes_to_modules(self):
+        """
+        Map FX graph node names to their originating nn.Module paths
+        using Dynamo's nn_module_stack metadata.
+
+        Returns:
+            Dict[str, Tuple[str, str]]:
+                FX node name -> (module_path, module_class)
+        """
+        graph = self.exported_program.graph_module.graph
+        node_to_module = {}
+
+        for node in graph.nodes:
+            mod_stack = node.meta.get("nn_module_stack", None)
+            if not mod_stack:
+                continue
+
+            module_path, module_class = list(mod_stack.values())[-1]
+            node_to_module[node.name] = (module_path, module_class)
+
+        return node_to_module
     
     def _parse_device_config(self, device):
         """

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -15,7 +15,7 @@ from .core.token_relevance_visuals import (
     plot_tokenwise_relevance_map_swapped,
     plot_input_heatmap_for_token,
 )
-from .core.visualization_module_aware import visualize_relevance_with_modules
+from .core.visualization_module_aware import visualize_relevance_with_module_labels
 
 import numpy as np 
 import torch
@@ -974,7 +974,8 @@ class DLBacktrace:
         inline_format="svg",
     ):
         """
-        Visualize relevance graph with FX node → nn.Module mapping.
+        Visualize relevance graph with FX node → nn.Module mapping,
+        using the new module-aware visualization function.
         """
         if not getattr(self, "fx_node_to_module", None):
             raise RuntimeError(
@@ -982,7 +983,8 @@ class DLBacktrace:
                 "Initialize DLBacktrace with collect_node_module_map=True."
             )
 
-        return visualize_relevance_with_modules(
+        # Call the new visualization function (not the old wrapper)
+        return visualize_relevance_with_module_labels(
             self.graph,
             self.all_wt,
             self.fx_node_to_module,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -15,6 +15,7 @@ from .core.token_relevance_visuals import (
     plot_tokenwise_relevance_map_swapped,
     plot_input_heatmap_for_token,
 )
+from .core.visualization_module_aware import visualize_relevance_with_modules
 
 import numpy as np 
 import torch
@@ -963,6 +964,31 @@ class DLBacktrace:
             fast_output_path="backtrace_collapsed_fast",  # path for large graphs
             show=True,                        # ⬅️ show in Colab
             inline_format="svg",              # or "png" if SVG too heavy
+        )
+
+    def visualize_dlbacktrace_with_modules(
+        self,
+        output_path="backtrace_graph_modules",
+        *,
+        show=True,
+        inline_format="svg",
+    ):
+        """
+        Visualize relevance graph with FX node → nn.Module mapping.
+        """
+        if not getattr(self, "fx_node_to_module", None):
+            raise RuntimeError(
+                "Module mapping not available. "
+                "Initialize DLBacktrace with collect_node_module_map=True."
+            )
+
+        return visualize_relevance_with_modules(
+            self.graph,
+            self.all_wt,
+            self.fx_node_to_module,
+            output_path=output_path,
+            show=show,
+            inline_format=inline_format,
         )
 
     def visualize_tokenwise_relevance_map(

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -546,11 +546,13 @@ class DLBacktrace:
         Args:
             task (str): Task type - "auto", "image-classification", "text-classification", or "generation"
                 - "auto": Automatically detect task based on inputs
+                - "tabular-classification": For PyTorch Tabular Classification models 
                 - "image-classification": For image classification models (e.g., MobileNet, ResNet)
                 - "text-classification": For text classification models (e.g., BERT sentiment)
                 - "generation": For text generation models (e.g., GPT, LLaMA)
             
             inputs: Input data for the model
+                - For tabular-classification: torch.Tensor of shape (B, F)
                 - For image-classification: torch.Tensor of shape (B, C, H, W)
                 - For text-classification: dict with 'input_ids' and 'attention_mask' or tuple of tensors
                 - For generation: dict with 'input_ids' and 'attention_mask' or tuple of tensors
@@ -582,9 +584,9 @@ class DLBacktrace:
                 - 'layerwise_output_trace': (if return_layerwise_output=True) Layer-wise output trace
         
         Examples:
-            # Image classification
+            # Image classification or Tabular classification
             results = dlb.run_task(
-                task="image-classification",
+                task="image-classification",  # "tabular-classification",
                 inputs=image_tensor
             )
             
@@ -607,15 +609,20 @@ class DLBacktrace:
                 return_scores=True
             )
         """
-        
+        # Validate task type
+        valid_tasks = [
+            "tabular-classification",
+            "image-classification", 
+            "text-classification", 
+            "generation"
+        ]
+
         # Auto-detect task if needed
         if task == "auto":
-            task = self._detect_task(inputs, tokenizer)
+            task = self._detect_task(inputs)
             if debug:
                 print(f"🔍 Auto-detected task: {task}")
-        
-        # Validate task type
-        valid_tasks = ["image-classification", "text-classification", "generation"]
+
         if task not in valid_tasks:
             raise ValueError(f"task must be one of {valid_tasks}, got: {task}")
         
@@ -679,7 +686,7 @@ class DLBacktrace:
                 print(f"🚀 Running {task} task...")
             
             # Prepare model inputs
-            if task == "image-classification":
+            if task in ["image-classification", "tabular-classification"]:
                 # Image input: single tensor
                 if isinstance(inputs, torch.Tensor):
                     model_inputs = (inputs,)
@@ -766,34 +773,38 @@ class DLBacktrace:
             
             return result
     
-    def _detect_task(self, inputs, tokenizer):
+    def _detect_task(self, inputs):
         """
         Auto-detect task type based on inputs and model characteristics.
         
         Returns:
             str: Detected task type
         """
-        # If tokenizer provided and inputs have input_ids, likely text-based
-        if tokenizer is not None:
-            if isinstance(inputs, dict) and "input_ids" in inputs:
-                # Check if model is generative (has generate method)
-                if hasattr(self.model, "generate"):
-                    return "generation"
-                else:
-                    return "text-classification"
-            elif isinstance(inputs, (tuple, list)) and len(inputs) >= 2:
-                # Assume (input_ids, attention_mask)
-                if hasattr(self.model, "generate"):
-                    return "generation"
-                else:
-                    return "text-classification"
         
-        # If single tensor input, likely image classification
+        # ------------------------------------------------------------------
+        # 1. TEXT INPUTS (dict or tuple formats)
+        # ------------------------------------------------------------------
+        if isinstance(inputs, dict) and "input_ids" in inputs:
+            # Check if model is generative (has generate method)
+            if hasattr(self.model, "generate"):
+                return "generation"
+            else:
+                return "text-classification"
+        elif isinstance(inputs, (tuple, list)) and len(inputs) >= 2:
+            # Assume (input_ids, attention_mask)
+            if hasattr(self.model, "generate"):
+                return "generation"
+            else:
+                return "text-classification"
+        
+        # ------------------------------------------------------------------
+        # 2. TENSOR INPUTS
+        # ------------------------------------------------------------------
         if isinstance(inputs, torch.Tensor):
             if inputs.dim() == 4:  # (B, C, H, W)
                 return "image-classification"
             elif inputs.dim() == 2:  # Could be input_ids (B, seq_len)
-                return "text-classification"
+                return "tabular-classification"
         
         # Default fallback
         return "image-classification"


### PR DESCRIPTION
## Summary

This PR extends DL-Backtrace with **optional, module-aware relevance visualization support** by enabling FX graph nodes to be mapped back to their originating `nn.Module` hierarchy using Dynamo metadata.
It also updates the README benchmark section to reflect accurate performance ranges based on the latest measurement graphs.

## Changes
- Added `collect_node_module_map` flag to `DLBacktrace.__init__`
- Introduced `map_fx_nodes_to_modules` helper to extract FX node → module mappings
- Attached module metadata to graph nodes in a non-invasive manner
- Added new module-aware relevance visualization utilities without modifying existing visualization APIs
- Updated README:
  - Revised **📊 Benchmark Summary** values to reflect real speedup ranges
  - Updated performance note under **📈 Performance Graphs** to:  
    *“DLB v2 provides consistent low latency and achieves **20×–1400× speedup** over DLB v1 as sequence length increases.”*
   - Updated Google Colab and HTML version links for the demo notebooks.
## Usage
```python
dlb = DLBacktrace(
    model,
    (input_ids, attention_mask),
    dynamic_shapes=dynamic_shapes, 
    collect_node_module_map=True
)

node_module_map = dlb.fx_node_to_module

# Standard visualization (unchanged)
dlb.visualize_dlbacktrace()

# Module-aware visualization
dlb.visualize_dlbacktrace_with_modules()
```