### PR TITLE
Add Relevance Trace Memory Controls

### DIFF
--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -322,7 +322,24 @@ class DLBAutoSampler:
         cache_dir: Optional[Path],
         target_dtype,
         move_to_cpu: bool,
+        use_compression: bool = True,
+        pickle_protocol: int = 4,
     ):
+        """
+        Store relevance entry according to specified policy.
+        
+        Args:
+            rel_dict: Relevance dictionary to store
+            policy: Cache policy ("full", "summary", "disk", "none")
+            step_idx: Generation step index
+            cache_dir: Directory for disk caching
+            target_dtype: Target dtype for compression
+            move_to_cpu: Whether to move tensors to CPU
+            use_compression: If True, use pickle protocol 4 for better compression (default: True)
+            pickle_protocol: Pickle protocol version (2-5). Higher = better compression.
+                            Protocol 4 (default): ~20-30% smaller files, Python 3.4+
+                            Protocol 5: Best compression, Python 3.8+
+        """
         normalized_policy = (policy or "full").lower()
         if normalized_policy == "none":
             return None
@@ -338,7 +355,19 @@ class DLBAutoSampler:
             if cache_dir is None:
                 raise ValueError("relevance_cache_dir must be provided when relevance_cache_policy='disk'")
             file_path = cache_dir / f"step_{step_idx:05d}.pt"
-            torch.save(processed, file_path)
+            
+            # Save with compression using higher pickle protocol
+            # Protocol 4+ provides better compression for large numpy/torch arrays
+            if use_compression:
+                torch.save(
+                    processed, 
+                    file_path,
+                    pickle_protocol=pickle_protocol,
+                    _use_new_zipfile_serialization=True  # Use ZIP64 format (PyTorch 1.6+)
+                )
+            else:
+                torch.save(processed, file_path)
+            
             return {
                 "summary": self._summarize_relevance(processed),
                 "path": str(file_path),
@@ -388,6 +417,8 @@ class DLBAutoSampler:
         relevance_cache_dir: Optional[str] = None,
         relevance_compress_dtype: Optional[Any] = "float16",
         relevance_move_to_cpu: bool = True,
+        relevance_use_compression: bool = True,
+        relevance_pickle_protocol: int = 4,
     ):
         """
         Always returns:
@@ -398,6 +429,8 @@ class DLBAutoSampler:
             relevance_cache_policy: "full" (default), "summary", "disk", or "none".
             relevance_cache_dir: base directory for on-disk caching (policy="disk").
             relevance_compress_dtype: dtype hint (str or torch.dtype) for stored tensors.
+            relevance_use_compression: If True, use optimized pickle protocol for compression (default: True).
+            relevance_pickle_protocol: Pickle protocol (2-5). Higher = better compression. Default=4.
             relevance_move_to_cpu: move tensors to CPU before caching to reduce VRAM.
         """ 
         model = self._get_causallm(self.dlb.model)
@@ -568,6 +601,8 @@ class DLBAutoSampler:
                         cache_dir=cache_dir_path,
                         target_dtype=cache_dtype,
                         move_to_cpu=relevance_move_to_cpu,
+                        use_compression=relevance_use_compression,
+                        pickle_protocol=relevance_pickle_protocol,
                     )
                     relevance_trace.append(entry)
 
@@ -782,6 +817,8 @@ class DLBAutoSampler:
                         cache_dir=cache_dir_path,
                         target_dtype=cache_dtype,
                         move_to_cpu=relevance_move_to_cpu,
+                        use_compression=relevance_use_compression,
+                        pickle_protocol=relevance_pickle_protocol,
                     )
                     step_rel_scores.append(entry)
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -100,12 +100,12 @@ class DLBAutoSampler:
         if path.suffix == '.gz':
             # Gzip compressed
             with gzip.open(path, 'rb') as f:
-                return torch.load(f)
+                return torch.load(f, weights_only=False)
         
         elif path.suffix == '.xz':
             # LZMA compressed
             with lzma.open(path, 'rb') as f:
-                return torch.load(f)
+                return torch.load(f, weights_only=False)
         
         elif path.suffix == '.7z':
             # 7z compressed
@@ -123,11 +123,11 @@ class DLBAutoSampler:
                 pt_files = list(tmpdir_path.glob('*.pt'))
                 if not pt_files:
                     raise ValueError(f"No .pt file found in 7z archive: {path}")
-                return torch.load(pt_files[0])
+                return torch.load(pt_files[0], weights_only=False)
         
         else:
             # Uncompressed or unknown format
-            return torch.load(path)
+            return torch.load(path, weights_only=False)
 
     # ---------- small dtype helpers ----------
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import time
+import numpy as np
 from pathlib import Path
 from typing import Optional, List, Tuple, cast, Any
 
@@ -285,6 +286,14 @@ class DLBAutoSampler:
             if target_dtype is not None:
                 tensor = tensor.to(dtype=target_dtype)
             return tensor.clone()
+        # Handle numpy arrays by converting to torch tensor with target dtype
+        if isinstance(data, np.ndarray):
+            tensor = torch.from_numpy(data)
+            if move_to_cpu:
+                tensor = tensor.to("cpu")
+            if target_dtype is not None:
+                tensor = tensor.to(dtype=target_dtype)
+            return tensor
         if isinstance(data, dict):
             return {k: self._compress_relevance_tree(v, target_dtype=target_dtype, move_to_cpu=move_to_cpu) for k, v in data.items()}
         if isinstance(data, list):

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -6,12 +6,20 @@ from __future__ import annotations
 
 import time
 import gzip
+import lzma
 import numpy as np
 from pathlib import Path
 from typing import Optional, List, Tuple, cast, Any
 
 import torch
 import torch.nn.functional as F
+
+# Optional: 7z support (requires py7zr)
+try:
+    import py7zr
+    HAS_7Z = True
+except ImportError:
+    HAS_7Z = False
 
 from transformers.generation.logits_process import (
     LogitsProcessorList,
@@ -70,6 +78,56 @@ class DLBAutoSampler:
     def __init__(self, dlb, tokenizer):
         self.dlb = dlb
         self.tokenizer = tokenizer
+
+    # ---------- compression helpers ----------
+
+    @staticmethod
+    def load_compressed_relevance(file_path: str):
+        """
+        Load relevance data from compressed file with automatic format detection.
+        
+        Args:
+            file_path: Path to compressed relevance file (.pt.gz, .pt.xz, .pt.7z, or .pt)
+        
+        Returns:
+            Loaded relevance dictionary
+        
+        Example:
+            >>> relevance = DLBAutoSampler.load_compressed_relevance("step_00000.pt.gz")
+        """
+        path = Path(file_path)
+        
+        if path.suffix == '.gz':
+            # Gzip compressed
+            with gzip.open(path, 'rb') as f:
+                return torch.load(f)
+        
+        elif path.suffix == '.xz':
+            # LZMA compressed
+            with lzma.open(path, 'rb') as f:
+                return torch.load(f)
+        
+        elif path.suffix == '.7z':
+            # 7z compressed
+            if not HAS_7Z:
+                raise ImportError(
+                    "py7zr library required to load 7z files. "
+                    "Install with: pip install py7zr"
+                )
+            import tempfile
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmpdir_path = Path(tmpdir)
+                with py7zr.SevenZipFile(path, 'r') as archive:
+                    archive.extractall(tmpdir_path)
+                # Find the extracted .pt file
+                pt_files = list(tmpdir_path.glob('*.pt'))
+                if not pt_files:
+                    raise ValueError(f"No .pt file found in 7z archive: {path}")
+                return torch.load(pt_files[0])
+        
+        else:
+            # Uncompressed or unknown format
+            return torch.load(path)
 
     # ---------- small dtype helpers ----------
 
@@ -324,6 +382,7 @@ class DLBAutoSampler:
         target_dtype,
         move_to_cpu: bool,
         use_compression: bool = True,
+        compression_method: str = "gzip",
         pickle_protocol: int = 4,
     ):
         """
@@ -336,7 +395,12 @@ class DLBAutoSampler:
             cache_dir: Directory for disk caching
             target_dtype: Target dtype for compression
             move_to_cpu: Whether to move tensors to CPU
-            use_compression: If True, use gzip compression for 2-3x additional size reduction (default: True)
+            use_compression: If True, use compression (default: True)
+            compression_method: Compression method - "gzip", "lzma", "7z", or "none"
+                              - "gzip": Fast, good compression (default)
+                              - "lzma": Better compression, slower
+                              - "7z": Best compression, slowest (requires py7zr)
+                              - "none": No compression
             pickle_protocol: Pickle protocol version (2-5). Higher = better compression.
                             Protocol 4 (default): Python 3.4+, good compression
                             Protocol 5: Best compression, Python 3.8+
@@ -355,29 +419,58 @@ class DLBAutoSampler:
         if normalized_policy == "disk":
             if cache_dir is None:
                 raise ValueError("relevance_cache_dir must be provided when relevance_cache_policy='disk'")
-            file_path = cache_dir / f"step_{step_idx:05d}.pt"
             
-            # Save with compression using higher pickle protocol
-            # Protocol 4+ provides better compression for large numpy/torch arrays
-            if use_compression:
-                # Use gzip compression for additional 2-3x size reduction
-                with gzip.open(str(file_path) + '.gz', 'wb', compresslevel=6) as f:
-                    torch.save(
-                        processed, 
-                        f,
-                        pickle_protocol=pickle_protocol,
+            base_file_path = cache_dir / f"step_{step_idx:05d}.pt"
+            
+            # Determine compression method and file extension
+            if not use_compression or compression_method == "none":
+                # No compression
+                file_path = base_file_path
+                torch.save(processed, file_path, pickle_protocol=pickle_protocol)
+            
+            elif compression_method == "gzip":
+                # Gzip compression (fast, good ratio)
+                file_path = Path(str(base_file_path) + '.gz')
+                with gzip.open(file_path, 'wb', compresslevel=6) as f:
+                    torch.save(processed, f, pickle_protocol=pickle_protocol)
+            
+            elif compression_method == "lzma":
+                # LZMA/xz compression (better ratio, slower)
+                file_path = Path(str(base_file_path) + '.xz')
+                with lzma.open(file_path, 'wb', preset=6) as f:
+                    torch.save(processed, f, pickle_protocol=pickle_protocol)
+            
+            elif compression_method == "7z":
+                # 7z compression (best ratio, slowest)
+                if not HAS_7Z:
+                    raise ImportError(
+                        "py7zr library required for 7z compression. "
+                        "Install with: pip install py7zr"
                     )
-                file_path = Path(str(file_path) + '.gz')
+                file_path = Path(str(base_file_path) + '.7z')
+                # Save to temporary .pt file first
+                import tempfile
+                with tempfile.NamedTemporaryFile(suffix='.pt', delete=False) as tmp:
+                    tmp_path = Path(tmp.name)
+                    torch.save(processed, tmp_path, pickle_protocol=pickle_protocol)
+                
+                # Compress with 7z
+                with py7zr.SevenZipFile(file_path, 'w') as archive:
+                    archive.write(tmp_path, arcname=f'step_{step_idx:05d}.pt')
+                
+                # Clean up temp file
+                tmp_path.unlink()
+            
             else:
-                torch.save(
-                    processed, 
-                    file_path,
-                    pickle_protocol=pickle_protocol,
+                raise ValueError(
+                    f"Unknown compression_method: {compression_method}. "
+                    f"Must be one of: 'gzip', 'lzma', '7z', 'none'"
                 )
             
             return {
                 "summary": self._summarize_relevance(processed),
                 "path": str(file_path),
+                "compression": compression_method,
             }
 
 
@@ -426,6 +519,7 @@ class DLBAutoSampler:
         relevance_compress_dtype: Optional[Any] = "float16",
         relevance_move_to_cpu: bool = True,
         relevance_use_compression: bool = True,
+        relevance_compression_method: str = "gzip",
         relevance_pickle_protocol: int = 4,
     ):
         """
@@ -437,8 +531,12 @@ class DLBAutoSampler:
             relevance_cache_policy: "full" (default), "summary", "disk", or "none".
             relevance_cache_dir: base directory for on-disk caching (policy="disk").
             relevance_compress_dtype: dtype hint (str or torch.dtype) for stored tensors.
-            relevance_use_compression: If True, use gzip compression + pickle protocol 4 (default: True).
-                                      Provides 2-3x additional size reduction beyond dtype compression.
+            relevance_use_compression: If True, use compression for disk storage (default: True).
+            relevance_compression_method: Compression method - "gzip" (default), "lzma", "7z", or "none".
+                                        - "gzip": Fast, good compression (~75% reduction)
+                                        - "lzma": Better compression (~80% reduction), slower
+                                        - "7z": Best compression (~82% reduction), slowest
+                                        - "none": No compression (only dtype compression)
             relevance_pickle_protocol: Pickle protocol (2-5). Higher = better compression. Default=4.
             relevance_move_to_cpu: move tensors to CPU before caching to reduce VRAM.
         """ 
@@ -611,6 +709,7 @@ class DLBAutoSampler:
                         target_dtype=cache_dtype,
                         move_to_cpu=relevance_move_to_cpu,
                         use_compression=relevance_use_compression,
+                        compression_method=relevance_compression_method,
                         pickle_protocol=relevance_pickle_protocol,
                     )
                     relevance_trace.append(entry)
@@ -827,6 +926,7 @@ class DLBAutoSampler:
                         target_dtype=cache_dtype,
                         move_to_cpu=relevance_move_to_cpu,
                         use_compression=relevance_use_compression,
+                        compression_method=relevance_compression_method,
                         pickle_protocol=relevance_pickle_protocol,
                     )
                     step_rel_scores.append(entry)

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import time
+import gzip
 import numpy as np
 from pathlib import Path
 from typing import Optional, List, Tuple, cast, Any
@@ -335,9 +336,9 @@ class DLBAutoSampler:
             cache_dir: Directory for disk caching
             target_dtype: Target dtype for compression
             move_to_cpu: Whether to move tensors to CPU
-            use_compression: If True, use pickle protocol 4 for better compression (default: True)
+            use_compression: If True, use gzip compression for 2-3x additional size reduction (default: True)
             pickle_protocol: Pickle protocol version (2-5). Higher = better compression.
-                            Protocol 4 (default): ~20-30% smaller files, Python 3.4+
+                            Protocol 4 (default): Python 3.4+, good compression
                             Protocol 5: Best compression, Python 3.8+
         """
         normalized_policy = (policy or "full").lower()
@@ -359,19 +360,26 @@ class DLBAutoSampler:
             # Save with compression using higher pickle protocol
             # Protocol 4+ provides better compression for large numpy/torch arrays
             if use_compression:
+                # Use gzip compression for additional 2-3x size reduction
+                with gzip.open(str(file_path) + '.gz', 'wb', compresslevel=6) as f:
+                    torch.save(
+                        processed, 
+                        f,
+                        pickle_protocol=pickle_protocol,
+                    )
+                file_path = Path(str(file_path) + '.gz')
+            else:
                 torch.save(
                     processed, 
                     file_path,
                     pickle_protocol=pickle_protocol,
-                    _use_new_zipfile_serialization=True  # Use ZIP64 format (PyTorch 1.6+)
                 )
-            else:
-                torch.save(processed, file_path)
             
             return {
                 "summary": self._summarize_relevance(processed),
                 "path": str(file_path),
             }
+
 
         if normalized_policy != "full":
             raise ValueError(
@@ -429,7 +437,8 @@ class DLBAutoSampler:
             relevance_cache_policy: "full" (default), "summary", "disk", or "none".
             relevance_cache_dir: base directory for on-disk caching (policy="disk").
             relevance_compress_dtype: dtype hint (str or torch.dtype) for stored tensors.
-            relevance_use_compression: If True, use optimized pickle protocol for compression (default: True).
+            relevance_use_compression: If True, use gzip compression + pickle protocol 4 (default: True).
+                                      Provides 2-3x additional size reduction beyond dtype compression.
             relevance_pickle_protocol: Pickle protocol (2-5). Higher = better compression. Default=4.
             relevance_move_to_cpu: move tensors to CPU before caching to reduce VRAM.
         """ 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import time
-from typing import Optional, List, Tuple, cast
+from pathlib import Path
+from typing import Optional, List, Tuple, cast, Any
 
 import torch
 import torch.nn.functional as F
@@ -252,6 +253,94 @@ class DLBAutoSampler:
         add_val(rel_dict)
         return total
 
+    @staticmethod
+    def _resolve_torch_dtype(dtype_hint):
+        if dtype_hint is None:
+            return None
+        if isinstance(dtype_hint, torch.dtype):
+            return dtype_hint
+        if isinstance(dtype_hint, str):
+            key = dtype_hint.strip().lower()
+            mapping = {
+                "float32": torch.float32,
+                "fp32": torch.float32,
+                "float": torch.float32,
+                "float16": torch.float16,
+                "fp16": torch.float16,
+                "half": torch.float16,
+                "bfloat16": torch.bfloat16,
+                "bf16": torch.bfloat16,
+                "float64": torch.float64,
+                "fp64": torch.float64,
+            }
+            if key in mapping:
+                return mapping[key]
+        raise ValueError(f"Unsupported relevance dtype hint: {dtype_hint}")
+
+    def _compress_relevance_tree(self, data, *, target_dtype=None, move_to_cpu=True):
+        if torch.is_tensor(data):
+            tensor = data.detach()
+            if move_to_cpu:
+                tensor = tensor.to("cpu")
+            if target_dtype is not None:
+                tensor = tensor.to(dtype=target_dtype)
+            return tensor.clone()
+        if isinstance(data, dict):
+            return {k: self._compress_relevance_tree(v, target_dtype=target_dtype, move_to_cpu=move_to_cpu) for k, v in data.items()}
+        if isinstance(data, list):
+            return [self._compress_relevance_tree(v, target_dtype=target_dtype, move_to_cpu=move_to_cpu) for v in data]
+        if isinstance(data, tuple):
+            return tuple(self._compress_relevance_tree(v, target_dtype=target_dtype, move_to_cpu=move_to_cpu) for v in data)
+        return data
+
+    def _prepare_cache_dir(self, base_dir: Optional[str], policy: str):
+        if policy != "disk":
+            return None
+        if not base_dir:
+            raise ValueError("relevance_cache_dir is required when relevance_cache_policy='disk'")
+        root = Path(base_dir).expanduser()
+        timestamp = int(time.time() * 1000)
+        run_dir = root / f"relevance_cache_run_{timestamp}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def _store_relevance_entry(
+        self,
+        rel_dict,
+        *,
+        policy: str,
+        step_idx: int,
+        cache_dir: Optional[Path],
+        target_dtype,
+        move_to_cpu: bool,
+    ):
+        normalized_policy = (policy or "full").lower()
+        if normalized_policy == "none":
+            return None
+
+        processed = self._compress_relevance_tree(rel_dict, target_dtype=target_dtype, move_to_cpu=move_to_cpu)
+        if processed is None:
+            return None
+
+        if normalized_policy == "summary":
+            return {"summary": self._summarize_relevance(processed)}
+
+        if normalized_policy == "disk":
+            if cache_dir is None:
+                raise ValueError("relevance_cache_dir must be provided when relevance_cache_policy='disk'")
+            file_path = cache_dir / f"step_{step_idx:05d}.pt"
+            torch.save(processed, file_path)
+            return {
+                "summary": self._summarize_relevance(processed),
+                "path": str(file_path),
+            }
+
+        if normalized_policy != "full":
+            raise ValueError(
+                "relevance_cache_policy must be one of {'full', 'summary', 'disk', 'none'}"
+            )
+        return processed
+
     # ---------- public API ----------
 
     @torch.no_grad()
@@ -286,16 +375,41 @@ class DLBAutoSampler:
         return_layerwise_output: bool = False,
         return_relevance: bool = False,
         debug: bool = False,
+        relevance_cache_policy: str = "full",
+        relevance_cache_dir: Optional[str] = None,
+        relevance_compress_dtype: Optional[Any] = "float16",
+        relevance_move_to_cpu: bool = True,
     ):
         """
         Always returns:
             - [1, T_total] (top-1 sequence)
             - Or (sequence, scores_trace) for sampling when return_scores=True
-        """
+
+        Relevance caching knobs:
+            relevance_cache_policy: "full" (default), "summary", "disk", or "none".
+            relevance_cache_dir: base directory for on-disk caching (policy="disk").
+            relevance_compress_dtype: dtype hint (str or torch.dtype) for stored tensors.
+            relevance_move_to_cpu: move tensors to CPU before caching to reduce VRAM.
+        """ 
         model = self._get_causallm(self.dlb.model)
         device = input_ids.device
         B = input_ids.size(0)
         assert B == 1, "Current implementation assumes batch size = 1."
+
+        cache_policy = (relevance_cache_policy or "full").lower()
+        allowed_policies = {"full", "summary", "disk", "none"}
+        if cache_policy not in allowed_policies:
+            raise ValueError(
+                "relevance_cache_policy must be one of {'full', 'summary', 'disk', 'none'}"
+            )
+        cache_dtype = (
+            self._resolve_torch_dtype(relevance_compress_dtype)
+            if relevance_compress_dtype is not None
+            else None
+        )
+        cache_dir_path = None
+        if return_relevance and cache_policy == "disk":
+            cache_dir_path = self._prepare_cache_dir(relevance_cache_dir, cache_policy)
 
         # Dtypes up-front
         input_ids = self._as_long(input_ids)
@@ -437,8 +551,16 @@ class DLBAutoSampler:
                         task="generation",
                         debug=False,
                     )
-                    # rel_scalar = self._summarize_relevance(rel_dict)
-                    relevance_trace.append(rel_dict)
+                    step_idx = len(relevance_trace)
+                    entry = self._store_relevance_entry(
+                        rel_dict,
+                        policy=cache_policy,
+                        step_idx=step_idx,
+                        cache_dir=cache_dir_path,
+                        target_dtype=cache_dtype,
+                        move_to_cpu=relevance_move_to_cpu,
+                    )
+                    relevance_trace.append(entry)
 
                 generated = torch.cat([generated, next_tokens], dim=1) 
                 attn = torch.cat(
@@ -473,6 +595,9 @@ class DLBAutoSampler:
                 info["scores_trace"] = scores_trace
             if return_relevance:
                 info["relevance_trace"] = relevance_trace
+                info["relevance_cache_policy"] = cache_policy
+                if cache_dir_path is not None:
+                    info["relevance_cache_dir"] = str(cache_dir_path)
             if return_layerwise_output:
                 info["layerwise_output_trace"] = io_data_trace
             return generated, info  # ([1, T], dict)
@@ -621,6 +746,7 @@ class DLBAutoSampler:
 
             if return_relevance:
                 step_rel_scores = []
+                step_offset = len(relevance_trace_beam)
                 for b in range(beams):
                     # Use the OLD beam state (before new token) for relevance computation
                     self.dlb.predict(
@@ -640,7 +766,15 @@ class DLBAutoSampler:
                         task="generation",
                         debug=False,
                     )
-                    step_rel_scores.append(rel_dict_b)
+                    entry = self._store_relevance_entry(
+                        rel_dict_b,
+                        policy=cache_policy,
+                        step_idx=step_offset * beams + b,
+                        cache_dir=cache_dir_path,
+                        target_dtype=cache_dtype,
+                        move_to_cpu=relevance_move_to_cpu,
+                    )
+                    step_rel_scores.append(entry)
 
                 relevance_trace_beam.append(step_rel_scores)
 
@@ -700,6 +834,9 @@ class DLBAutoSampler:
                 for step_rels in relevance_trace_beam
             ]
             info_beam["relevance_trace"] = flat_relevance
+            info_beam["relevance_cache_policy"] = cache_policy
+            if cache_dir_path is not None:
+                info_beam["relevance_cache_dir"] = str(cache_dir_path)
         if return_layerwise_output:
             # collapse to top-1 beam (final winner)
             flat_io_trace = [

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/relevance_propagation.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/relevance_propagation.py
@@ -15,20 +15,20 @@ def log(*args, **kwargs):
 
 
 def tensor_to_numpy(x):
-    """Convert Tensor, scalar, list/tuple, or ndarray to a NumPy array with memory-efficient float32."""
+    """Convert Tensor, scalar, list/tuple, or ndarray to a NumPy array, preserving dtype when possible."""
     if isinstance(x, np.ndarray):
-        # Convert to float32 if it's float64 to save memory
+        # Only convert float64 to float32 to save memory
         return x.astype(np.float32) if x.dtype == np.float64 else x
     if isinstance(x, torch.Tensor):
-        # Use float32 for memory efficiency
-        return x.detach().cpu().numpy().astype(np.float32)
+        # Preserve original dtype - don't force float32
+        return x.detach().cpu().numpy()
     if isinstance(x, (int, float)):
         return np.array(x, dtype=np.float32)
     if isinstance(x, (list, tuple)):
         arrs = []
         for xi in x:
             converted = tensor_to_numpy(xi) if not isinstance(xi, np.ndarray) else xi
-            # Ensure float32 for memory efficiency
+            # Only convert float64 to float32
             if hasattr(converted, 'dtype') and converted.dtype == np.float64:
                 converted = converted.astype(np.float32)
             arrs.append(converted)
@@ -40,23 +40,20 @@ def tensor_to_numpy(x):
 
 
 def process_input_for_eval(X):
-    """Unwrap single-element or multi-element lists/tuples and convert to NumPy with memory optimization."""
+    """Unwrap single-element or multi-element lists/tuples and convert to NumPy, preserving dtype when possible."""
     # Handle lists/tuples
     if isinstance(X, (list, tuple)):
         X = X[0] if len(X) == 1 else X[0]  # Assume first element is the actual input tensor
 
-    # Convert torch.Tensor to NumPy with memory-efficient float32
+    # Convert torch.Tensor to NumPy - preserve original dtype
     if isinstance(X, torch.Tensor):
         if X.is_cuda:
             X = X.cpu()
         
-        # Avoid copy if already float32 and contiguous
-        if X.dtype == torch.float32 and X.is_contiguous():
-            return X.detach().numpy()
-        else:
-            return X.detach().to(torch.float32).numpy()
+        # Preserve original dtype
+        return X.detach().numpy()
 
-    # Already a NumPy array - ensure float32 for memory efficiency
+    # Already a NumPy array - only convert float64 to float32
     if isinstance(X, np.ndarray):
         return X.astype(np.float32, copy=False) if X.dtype == np.float64 else X
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -537,6 +537,10 @@ class DLBacktrace:
         return_scores=False,
         return_relevance=False,
         return_layerwise_output=False,
+        relevance_cache_policy="full",
+        relevance_cache_dir=None,
+        relevance_compress_dtype="float16",
+        relevance_move_to_cpu=True,
         debug=False,
         **generation_kwargs
     ):
@@ -567,6 +571,11 @@ class DLBacktrace:
             return_scores (bool): Return scores trace (default: False)
             return_relevance (bool): Return relevance trace (default: False)
             return_layerwise_output (bool): Return layer-wise output trace (default: False)
+            relevance_cache_policy (str): "full", "summary", "disk", or "none" storage policy for
+                per-token relevance data when generation traces are requested.
+            relevance_cache_dir (str | None): Directory root for on-disk relevance caching.
+            relevance_compress_dtype (str | torch.dtype): Target dtype for cached tensors (default: float16).
+            relevance_move_to_cpu (bool): Move cached relevance tensors to CPU memory (default: True).
             debug (bool): Enable debug logging (default: False)
             
             **generation_kwargs: Additional kwargs for generation task (passed to sample_auto)
@@ -645,6 +654,15 @@ class DLBacktrace:
             if debug:
                 print(f"🚀 Running generation task with sample_auto...")
             
+            cache_kwargs = {
+                "relevance_cache_policy": relevance_cache_policy,
+                "relevance_cache_dir": relevance_cache_dir,
+                "relevance_compress_dtype": relevance_compress_dtype,
+                "relevance_move_to_cpu": relevance_move_to_cpu,
+            }
+            for key, value in cache_kwargs.items():
+                generation_kwargs.setdefault(key, value)
+
             # Call sample_auto with generation kwargs and trace flags
             generated_output = self.sample_auto(
                 tokenizer=tokenizer,
@@ -815,7 +833,9 @@ class DLBacktrace:
         Accepts kwargs: temperature, top_k, top_p, max_new_tokens, min_new_tokens, max_time,
                         early_stopping, repetition_penalty, no_repeat_ngram_size,
                         bad_words_ids, bos_token_id, eos_token_id, pad_token_id,
-                        num_beams, num_return_sequences, length_penalty, return_scores, debug
+                        num_beams, num_return_sequences, length_penalty, return_scores, debug,
+                        relevance_cache_policy, relevance_cache_dir,
+                        relevance_compress_dtype, relevance_move_to_cpu
 
         Returns:
             - Always a single sequence with shape [1, T_total]

--- a/docs/examples/colab-notebooks.md
+++ b/docs/examples/colab-notebooks.md
@@ -86,7 +86,7 @@ Lightweight model explanations.
 #### BERT Sentiment Analysis
 Explain BERT classifications.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1eBAQ8TToJUs6EN4-md08cjfZUmAArX0s?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1eBAQ8TToJUs6EN4-md08cjfZUmAArX0s?usp=drive_link)
 
 **What you'll learn:**
 - BERT model tracing
@@ -112,7 +112,7 @@ Explain LLaMA predictions.
 #### Qwen-3-0.6B Text Generation
 Explain Qwen predictions.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1nJsxk7HPhiZ1DUIXn0eOnu0yjye-WOQT?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1nJsxk7HPhiZ1DUIXn0eOnu0yjye-WOQT?usp=drive_link)
 
 **What you'll learn:**
 - Scaling law effects
@@ -126,7 +126,7 @@ Explain Qwen predictions.
 #### JetMoE 
 Explain JetMoE expert routing decisions.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1MKxR60Mf1F_TNMuE31T3GRWHFPTm5IhP?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1MKxR60Mf1F_TNMuE31T3GRWHFPTm5IhP?usp=drive_link)
 
 **What you'll learn:**
 - MoE model tracing
@@ -139,7 +139,7 @@ Explain JetMoE expert routing decisions.
 #### OLMoE 
 Explain OLMoE predictions and expert selection.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1e13QAFw4A8jKhZVb1jh-C_16A2u1vZIH?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1e13QAFw4A8jKhZVb1jh-C_16A2u1vZIH?usp=drive_link)
 
 **What you'll learn:**
 - MoE model tracing
@@ -180,7 +180,7 @@ Explain GPT-Oss open-source MoE predictions.
 #### Custom Tabular Binary Classification
 Explain tabular models.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1TqgeeBqQ1G9UGWfHV0MUloCccalpsRCh?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/13N2sfAxA_7GJsZ7VAKS5WIOg6GusQghI?usp=sharing)
 
 **What you'll learn:**
 - Feature importance for tabular data

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tqdm
 scikit-image
 lime
 tensorflow
+py7zr


### PR DESCRIPTION
- introduce relevance cache policy knobs (full|summary|disk|none) across `run_task`→`sample_auto`→`DLBAutoSampler.generate`
- add helpers for tensor compaction, dtype downcast, CPU/off-disk storage, and inline metadata so notebooks can stream relevance traces safely
- document new parameters in `run_task` docstring to keep API self-explanatory
- update the URLs of Colab notebooks in the documentation