### PR TITLE
Fixed torch version mismatch when installing from pypi

### DIFF
--- a/dl_backtrace/__main__.py
+++ b/dl_backtrace/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running DLBacktrace CLI via: python -m dl_backtrace"""
+from dl_backtrace.cli.engine import main
+
+if __name__ == "__main__":
+    main()

--- a/dl_backtrace/cli/engine.py
+++ b/dl_backtrace/cli/engine.py
@@ -552,6 +552,7 @@ def print_gen_table(records: List[Dict[str, Any]]):
 def save_report(
     seq_records: List[Dict[str, Any]],
     gen_records: List[Dict[str, Any]],
+    moe_records: List[Dict[str, Any]],
     system_info: Dict[str, Any],
     output_dir: str,
 ):
@@ -559,7 +560,8 @@ def save_report(
     os.makedirs(output_dir, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     path = os.path.join(output_dir, f"benchmark_{timestamp}.json")
-
+    moe_path = os.path.join(output_dir, f"moe_benchmark_{timestamp}.json")
+    
     report = {
         "timestamp": timestamp,
         "system_info": system_info,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,12 +8,7 @@
 ARG BASE_IMAGE=nvidia/cuda:13.1.1-runtime-ubuntu24.04
 FROM ${BASE_IMAGE}
 
-# Prevent interactive prompts during apt installs
 ENV DEBIAN_FRONTEND=noninteractive
-
-# ── Build args ──────────────────────────────────────────────
-ARG REPO_URL=https://github.com/omkararyaai/DLBacktrace.git
-ARG REPO_BRANCH=dlb_v2
 
 # ── System packages ─────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -27,27 +22,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Ensure `python` and `pip` point to python3
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # ── Python package manager ──────────────────────────────────
 RUN pip install --no-cache-dir --break-system-packages uv
 
-# ── Clone repository ────────────────────────────────────────
-WORKDIR /app
-RUN git clone --depth 1 --branch ${REPO_BRANCH} ${REPO_URL} . \
-    && rm -rf .git
-
 # ── Python dependencies ─────────────────────────────────────
-RUN uv pip install --no-cache --system --break-system-packages \
-        -r requirements.txt
+RUN uv pip install --no-cache --system \
+        torch==2.6.0+cu126 \
+        torchvision==0.21.0+cu126 \
+        torchaudio==2.6.0+cu126 \
+        --extra-index-url https://download.pytorch.org/whl/cu126
 
-# Install DLBacktrace from local source in editable mode
-RUN uv pip install --no-cache --system --break-system-packages \
-        -e .
-
-# Install DLB engine dependencies
-RUN uv pip install --no-cache --system --break-system-packages \
+# Install dl-backtrace from PyPI
+RUN uv pip install --no-cache --system \
+        dl-backtrace==0.1.14 \
         psutil tabulate lz4
 
 # ── Cleanup ─────────────────────────────────────────────────
@@ -60,5 +49,6 @@ ENV CUBLAS_WORKSPACE_CONFIG=":4096:8"
 ENV PYTHONWARNINGS="ignore"
 ENV TRANSFORMERS_VERBOSITY="error"
 
-# Default: run the DLB engine
+WORKDIR /app
+
 CMD ["python", "engine.py", "--mode", "gen", "--device", "cuda"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN uv pip install --no-cache --system \
 
 # Install dl-backtrace from PyPI
 RUN uv pip install --no-cache --system \
+        transformers==4.52.3 \
         dl-backtrace==0.1.14 \
         psutil tabulate lz4
 
@@ -51,4 +52,4 @@ ENV TRANSFORMERS_VERBOSITY="error"
 
 WORKDIR /app
 
-CMD ["python", "engine.py", "--mode", "gen", "--device", "cuda"]
+CMD ["python", "-m", "dl_backtrace", "--mode", "gen", "--device", "cuda"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
---extra-index-url https://download.pytorch.org/whl/cu126
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0
 huggingface-hub
 lz4
 matplotlib


### PR DESCRIPTION
When installing from pypi, the extra index flags required for cuda were being ignored, which resulted in installation of base cuda flags for that particular torch version(i.e for our case cu124 instead of cu126).
Setting explicit torch and transformer installation before running solves this, along with removal for internal requirements.txt and pyproject.toml torch installations.
This was causing cuda .so compiled files to break as they explicitly need cu126.