### PR TITLE
KV cache and other changes for forward pass

### DIFF
--- a/dl_backtrace/cli/engine.py
+++ b/dl_backtrace/cli/engine.py
@@ -303,7 +303,7 @@ def benchmark_gen_scaling(
     device: str,
     input_prompt: str = "What is the capital of France?",
     run_idx: int = 0,
-    cache_dir: str = "benchmarks/cache",
+    cache_dir: str = None,
     explain_tokens = "all",
 ) -> Dict[str, Any]:
     """Benchmark multi-token generation using run_task(task='generation').
@@ -364,12 +364,12 @@ def benchmark_gen_scaling(
             inputs={"input_ids": input_ids, "attention_mask": attention_mask},
             tokenizer=tokenizer,
             max_new_tokens=max_new_tokens,
-            return_relevance=True,
-            return_scores=True,
+            return_relevance=False,
+            return_scores=False,
             debug=False,
             explain_tokens=explain_tokens,
-            relevance_cache_policy="disk",
-            relevance_cache_dir=cache_dir,
+            relevance_cache_policy="none",
+            relevance_cache_dir=None,
         )
         if device == "cuda":
             torch.cuda.synchronize()

--- a/dl_backtrace/cli/engine.py
+++ b/dl_backtrace/cli/engine.py
@@ -368,8 +368,8 @@ def benchmark_gen_scaling(
             return_scores=False,
             debug=False,
             explain_tokens=explain_tokens,
-            relevance_cache_policy="none",
-            relevance_cache_dir=None,
+            relevance_cache_policy="disk",
+            relevance_cache_dir=cache_dir,
         )
         if device == "cuda":
             torch.cuda.synchronize()

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -238,19 +238,35 @@ class DLBAutoSampler:
         """Save tensor/dict data to disk with optional lz4 compression. Returns the file path."""
         base_path = cache_dir / filename
 
+        # Types that are safe to pickle (primitives + containers)
+        _SAFE_SCALARS = (int, float, bool, str, bytes, type(None))
+
         def _to_cpu_async(obj):
+            """Recursively move tensors to CPU and drop non-serializable objects."""
             if torch.is_tensor(obj):
                 t = obj.detach()
                 return t.to('cpu', non_blocking=True) if t.is_cuda else t
             if isinstance(obj, np.ndarray):
                 return torch.from_numpy(obj)
             if isinstance(obj, dict):
-                return {k: _to_cpu_async(v) for k, v in obj.items()}
+                return {k: _to_cpu_async(v) for k, v in obj.items()
+                        if _is_serializable(v)}
             if isinstance(obj, list):
-                return [_to_cpu_async(v) for v in obj]
+                return [_to_cpu_async(v) for v in obj if _is_serializable(v)]
             if isinstance(obj, tuple):
-                return tuple(_to_cpu_async(v) for v in obj)
-            return obj
+                return tuple(_to_cpu_async(v) for v in obj if _is_serializable(v))
+            if isinstance(obj, _SAFE_SCALARS):
+                return obj
+            # Drop anything else (PyCapsule, C-objects, HF cache internals, etc.)
+            return None
+
+        def _is_serializable(obj):
+            """Quick check: is this object (or container of objects) safe to pickle?"""
+            if torch.is_tensor(obj) or isinstance(obj, (np.ndarray, *_SAFE_SCALARS)):
+                return True
+            if isinstance(obj, (dict, list, tuple)):
+                return True
+            return False
 
         cpu_data = _to_cpu_async(data)
         if torch.cuda.is_available():

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -271,7 +271,7 @@ class DLBAutoSampler:
             torch.save(cpu_data, file_path, pickle_protocol=pickle_protocol)
 
         del cpu_data
-        gc.collect()
+        # gc.collect()
         return str(file_path)
 
     def _print_generated_sequence(self, generated: torch.Tensor, prefix: str = ""):
@@ -496,40 +496,6 @@ class DLBAutoSampler:
                 return mapping[key]
         raise ValueError(f"Unsupported relevance dtype hint: {dtype_hint}")
 
-    @staticmethod
-    def load_relevance_trace(relevance_trace: list, device: str = "cpu") -> list:
-        """
-        Materialize a relevance_trace that may contain disk-stub entries.
-
-        When relevance_cache_policy="disk", each entry in relevance_trace is a dict:
-            {"summary": <float>, "path": <str>, "compression": <str>}
-        instead of a full {node_name: tensor} dict.
-
-        This function loads those stubs back from disk so the trace can be
-        passed to visualization functions.
-
-        Args:
-            relevance_trace: list of either {node: tensor} dicts (full/summary policy)
-                            or {"path": ..., "summary": ..., "compression": ...} stubs (disk policy)
-            device: torch device string for loaded tensors (default "cpu")
-
-        Returns:
-            list of {node_name: tensor} dicts, ready for visualizers
-        """
-        loaded = []
-        for entry in relevance_trace:
-            if not isinstance(entry, dict):
-                loaded.append(entry)
-                continue
-            # Detect disk stub: has "path" key pointing to a .dlbr file
-            if "path" in entry and "summary" in entry:
-                tensors = DLBAutoSampler.load_relevance_step(entry["path"], device=device)
-                loaded.append(tensors)
-            else:
-                # Already a full {node: tensor} dict (policy="full") — pass through
-                loaded.append(entry)
-
-        return loaded
 
     def _prepare_cache_dir(self, base_dir: Optional[str], policy: str):
         if policy != "disk":
@@ -675,7 +641,7 @@ class DLBAutoSampler:
                 f.write(raw_bytes)
         del raw_bytes
 
-        gc.collect()
+        # gc.collect()
         return {
             "summary": summary_val,
             "path": str(file_path),
@@ -1034,7 +1000,7 @@ class DLBAutoSampler:
                         )
                         io_data_trace.append({"path": path})
                         del io_data
-                        gc.collect()
+                        # gc.collect()
                     else:
                         io_data_trace.append(io_data)
                 _t["io_save"] = time.perf_counter() - _ts

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1003,10 +1003,8 @@ class DLBAutoSampler:
                             pickle_protocol=relevance_pickle_protocol,
                         )
                         scores_trace.append({"path": path})
-                        del scores_cpu
                     else:
                         scores_trace.append(scores_cpu)
-                    del scores
                     del scores_cpu
                 _t["scores_save"] = time.perf_counter() - _ts
 
@@ -1049,10 +1047,10 @@ class DLBAutoSampler:
                     torch.cuda.synchronize()
                 _t["backtrace"] = time.perf_counter() - _ts
 
-                # ── Stage F: Save relevance to disk ──
+                # ── Stage F: Save relevance ──
                 _ts = time.perf_counter()
-                if return_relevance and cache_policy == "disk":
-                    if _should_run_dlb(_gen_step_idx):
+                if return_relevance and _should_run_dlb(_gen_step_idx):
+                    if cache_policy == "disk":
                         entry = self._store_relevance_entry(
                             rel_dict,
                             policy=cache_policy,
@@ -1064,20 +1062,30 @@ class DLBAutoSampler:
                             compression_method=relevance_compression_method,
                             pickle_protocol=relevance_pickle_protocol,
                         )
+                        relevance_trace.append(entry)
+                        # _store_relevance_entry already calls rel_dict.clear()
+                        # for disk policy, so nothing left to free
+                    elif cache_policy == "full":
+                        # Deep-copy tensors to CPU so we can safely free GPU memory
+                        cpu_rel = {}
+                        for k, v in rel_dict.items():
+                            if torch.is_tensor(v):
+                                cpu_rel[k] = v.detach().cpu().clone()
+                            else:
+                                cpu_rel[k] = v
+                        relevance_trace.append(cpu_rel)
+                        del cpu_rel
                 _t["relevance_save"] = time.perf_counter() - _ts
 
-                if _should_run_dlb(_gen_step_idx) and cache_policy == "full":
-                    relevance_trace.append(rel_dict)
-                elif cache_policy == "disk":
-                    relevance_trace.append(entry)
-                    
                 # ── Stage G: Memory cleanup ──
                 _ts = time.perf_counter()
                 if rel_dict is not None:
-                    rel_dict.clear()
+                    # Safe to clear — "full" policy already copied tensors above,
+                    # "disk" policy already consumed the data in _store_relevance_entry
+                    if isinstance(rel_dict, dict):
+                        rel_dict.clear()
                     del rel_dict
                     rel_dict = None
-                    
                 _t["cleanup"] = time.perf_counter() - _ts
 
                 _t["total"] = _t["predict"] + _t["sampling"] + _t["scores_save"] + _t["io_save"] + _t["backtrace"] + _t["relevance_save"] + _t["cleanup"]

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -992,8 +992,8 @@ class DLBAutoSampler:
                 # ── Stage C: Save scores to disk ──
                 _ts = time.perf_counter()
                 if return_scores:
+                    scores_cpu = scores.detach().to("cpu")
                     if disk_streaming:
-                        scores_cpu = scores.detach().to("cpu")
                         path = self._save_to_disk(
                             scores_cpu,
                             cache_dir=cache_dir_path,
@@ -1005,8 +1005,9 @@ class DLBAutoSampler:
                         scores_trace.append({"path": path})
                         del scores_cpu
                     else:
-                        scores_trace.append(scores)
+                        scores_trace.append(scores_cpu)
                     del scores
+                    del scores_cpu
                 _t["scores_save"] = time.perf_counter() - _ts
 
                 # ── Stage D: Save IO data to disk ──
@@ -1064,9 +1065,13 @@ class DLBAutoSampler:
                             compression_method=relevance_compression_method,
                             pickle_protocol=relevance_pickle_protocol,
                         )
-                        relevance_trace.append(entry)
                 _t["relevance_save"] = time.perf_counter() - _ts
 
+                if _should_run_dlb(_gen_step_idx) and cache_policy == "full":
+                    relevance_trace.append(rel_dict)
+                elif cache_policy == "disk":
+                    relevance_trace.append(entry)
+                    
                 # ── Stage G: Memory cleanup ──
                 _ts = time.perf_counter()
                 if rel_dict is not None:

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -991,7 +991,7 @@ class DLBAutoSampler:
 
                 # ── Stage C: Save scores to disk ──
                 _ts = time.perf_counter()
-                if return_scores and _should_run_dlb(_gen_step_idx):
+                if return_scores:
                     if disk_streaming:
                         scores_cpu = scores.detach().to("cpu")
                         path = self._save_to_disk(
@@ -1042,13 +1042,16 @@ class DLBAutoSampler:
                         task="generation",
                         debug=False,
                     )
+                    self.dlb.all_wt = {}    
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
                 if device == "cuda":
                     torch.cuda.synchronize()
                 _t["backtrace"] = time.perf_counter() - _ts
 
                 # ── Stage F: Save relevance to disk ──
                 _ts = time.perf_counter()
-                if return_relevance:
+                if return_relevance and cache_policy == "disk":
                     if _should_run_dlb(_gen_step_idx):
                         entry = self._store_relevance_entry(
                             rel_dict,
@@ -1062,10 +1065,6 @@ class DLBAutoSampler:
                             pickle_protocol=relevance_pickle_protocol,
                         )
                         relevance_trace.append(entry)
-                        
-                        self.dlb.all_wt = {}    
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──
@@ -1074,6 +1073,7 @@ class DLBAutoSampler:
                     rel_dict.clear()
                     del rel_dict
                     rel_dict = None
+                    
                 _t["cleanup"] = time.perf_counter() - _ts
 
                 _t["total"] = _t["predict"] + _t["sampling"] + _t["scores_save"] + _t["io_save"] + _t["backtrace"] + _t["relevance_save"] + _t["cleanup"]

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1042,8 +1042,7 @@ class DLBAutoSampler:
                         thresholding=0.5,
                         task="generation",
                         debug=False,
-                    )
-                    self.dlb.all_wt = {}    
+                    )  
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()
                 if device == "cuda":

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -120,9 +120,6 @@ class DLBAutoSampler:
             all_wt.clear()
         self.dlb.all_wt = {}
 
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-
     # -- Native Forward with KV-Cache (Fast Path) --------------------------
 
     def _check_native_forward_support(self):
@@ -932,7 +929,7 @@ class DLBAutoSampler:
 
                 if _use_dlb:
                     # ── SLOW PATH: clear BEFORE allocating ──
-                    # Kill old node_io/all_wt first so peak RAM = 1× not 2×
+                    # Kill old node_io/all_wt first so peak RAM
                     self._clear_dlb_memory()
                     if _past_kv is not None:
                         del _past_kv
@@ -946,7 +943,8 @@ class DLBAutoSampler:
                         del io_data
                         io_data = None
                 else:
-                    # ── FAST PATH: Native model with KV-cache (~10-30 ms/token) ──
+                    # ── FAST PATH: Native model with KV-cache
+                    
                     logits, _past_kv = self._native_forward_with_cache(
                         generated, attn, past_key_values=_past_kv,
                         target_device=device,
@@ -994,8 +992,8 @@ class DLBAutoSampler:
                 # ── Stage C: Save scores to disk ──
                 _ts = time.perf_counter()
                 if return_scores and _should_run_dlb(_gen_step_idx):
-                    scores_cpu = scores.detach().to("cpu")
                     if disk_streaming:
+                        scores_cpu = scores.detach().to("cpu")
                         path = self._save_to_disk(
                             scores_cpu,
                             cache_dir=cache_dir_path,
@@ -1007,7 +1005,8 @@ class DLBAutoSampler:
                         scores_trace.append({"path": path})
                         del scores_cpu
                     else:
-                        scores_trace.append(scores_cpu)
+                        scores_trace.append(scores)
+                    del scores
                 _t["scores_save"] = time.perf_counter() - _ts
 
                 # ── Stage D: Save IO data to disk ──
@@ -1064,8 +1063,12 @@ class DLBAutoSampler:
                         )
                         relevance_trace.append(entry)
                         # Free the caller-side GPU reference immediately
-                        del rel_dict
-                        rel_dict = None
+                        if rel_dict is not None:
+                            rel_dict.clear()
+                            del rel_dict
+                        self.dlb.all_wt = {}    
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1062,20 +1062,13 @@ class DLBAutoSampler:
                             pickle_protocol=relevance_pickle_protocol,
                         )
                         relevance_trace.append(entry)
-                        # Free the caller-side GPU reference immediately
-                        if rel_dict is not None:
-                            rel_dict.clear()
-                            del rel_dict
+                        
                         self.dlb.all_wt = {}    
                         if torch.cuda.is_available():
                             torch.cuda.empty_cache()
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──
-                # _clear_dlb_memory() is now called PRE-step (before predict),
-                # so there's nothing to clear here after relevance is saved.
-                # We still need to free rel_dict if it wasn't consumed by
-                # _store_relevance_entry (e.g. return_relevance=False).
                 _ts = time.perf_counter()
                 if rel_dict is not None:
                     rel_dict.clear()

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -93,18 +93,21 @@ class DLBAutoSampler:
         self.tokenizer = tokenizer
 
     def _clear_dlb_memory(self):
-        """Clear DLB intermediate storage (node_io + all_wt).
+        """Clear DLB intermediate storage (node_io + all_wt) and defragment CUDA cache.
         
-        Note: torch.cuda.empty_cache() and gc.collect() intentionally NOT called here.
-        empty_cache() releases ALL cached GPU memory back to the OS, forcing CUDA to
-        reallocate everything from scratch on the next predict() call. As tensors grow
-        with sequence length, this reallocation cost grows proportionally — it was the
-        primary cause of predict() time increasing ~0.5s per 50 tokens.
-        Python's reference-counting GC handles the freed dicts immediately.
+        Note: gc.collect() intentionally NOT called here — it forces a full Python GC sweep
+        (~10-50ms) on every step. Python's reference counting handles the freed dicts immediately.
+        
+        torch.cuda.empty_cache() IS called because, as sequence length grows each step, new
+        tensors are slightly larger than old ones. Without defragmenting, the CUDA allocator's
+        cached blocks from previous (smaller) tensors can't serve new (larger) requests,
+        eventually causing OOM around 250 tokens.
         """
         self.dlb.node_io = {}
         if hasattr(self.dlb, 'all_wt'):
             self.dlb.all_wt = {}
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def _save_to_disk(
         self,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -119,6 +119,7 @@ class DLBAutoSampler:
                     del v
             all_wt.clear()
         self.dlb.all_wt = {}
+        # gc.collect()
 
     # -- Native Forward with KV-Cache (Fast Path) --------------------------
 
@@ -599,12 +600,9 @@ class DLBAutoSampler:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-        if normalized_policy == "summary":
+        if normalized_policy == "summary" or normalized_policy == "full":
             cpu_dict = self._flat_to_dict(flat_cpu, meta_entries)
             return {"summary": self._summarize_relevance(cpu_dict)}
-
-        if normalized_policy == "full":
-            return self._flat_to_dict(flat_cpu, meta_entries)
 
         if normalized_policy != "disk":
             raise ValueError(
@@ -1066,7 +1064,7 @@ class DLBAutoSampler:
                         # _store_relevance_entry already calls rel_dict.clear()
                         # for disk policy, so nothing left to free
                     elif cache_policy == "full":
-                        # Only keep the LAST DLB step's relevance in memory
+                        # Deep-copy tensors to CPU so we can safely free GPU memory
                         full_rel = self._store_relevance_entry(
                             rel_dict,
                             policy=cache_policy,
@@ -1078,8 +1076,8 @@ class DLBAutoSampler:
                             compression_method=relevance_compression_method,
                             pickle_protocol=relevance_pickle_protocol,
                         )
-                        relevance_trace.clear()
                         relevance_trace.append(full_rel)
+                        full_rel.clear()
                         del full_rel
                 _t["relevance_save"] = time.perf_counter() - _ts
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1066,7 +1066,7 @@ class DLBAutoSampler:
                         # _store_relevance_entry already calls rel_dict.clear()
                         # for disk policy, so nothing left to free
                     elif cache_policy == "full":
-                        # Deep-copy tensors to CPU so we can safely free GPU memory
+                        # Only keep the LAST DLB step's relevance in memory
                         full_rel = self._store_relevance_entry(
                             rel_dict,
                             policy=cache_policy,
@@ -1078,6 +1078,7 @@ class DLBAutoSampler:
                             compression_method=relevance_compression_method,
                             pickle_protocol=relevance_pickle_protocol,
                         )
+                        relevance_trace.clear()
                         relevance_trace.append(full_rel)
                         del full_rel
                 _t["relevance_save"] = time.perf_counter() - _ts

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -731,7 +731,7 @@ class DLBAutoSampler:
         return_relevance: bool = False,
         explain_tokens = "all",
         debug: bool = False,
-        relevance_cache_policy: str = "none",
+        relevance_cache_policy: str = "full",
         relevance_cache_dir: Optional[str] = None,
         relevance_compress_dtype: Optional[Any] = "float16",
         relevance_move_to_cpu: bool = True,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -496,6 +496,40 @@ class DLBAutoSampler:
                 return mapping[key]
         raise ValueError(f"Unsupported relevance dtype hint: {dtype_hint}")
 
+    @staticmethod
+    def load_relevance_trace(relevance_trace: list, device: str = "cpu") -> list:
+        """
+        Materialize a relevance_trace that may contain disk-stub entries.
+
+        When relevance_cache_policy="disk", each entry in relevance_trace is a dict:
+            {"summary": <float>, "path": <str>, "compression": <str>}
+        instead of a full {node_name: tensor} dict.
+
+        This function loads those stubs back from disk so the trace can be
+        passed to visualization functions.
+
+        Args:
+            relevance_trace: list of either {node: tensor} dicts (full/summary policy)
+                            or {"path": ..., "summary": ..., "compression": ...} stubs (disk policy)
+            device: torch device string for loaded tensors (default "cpu")
+
+        Returns:
+            list of {node_name: tensor} dicts, ready for visualizers
+        """
+        loaded = []
+        for entry in relevance_trace:
+            if not isinstance(entry, dict):
+                loaded.append(entry)
+                continue
+            # Detect disk stub: has "path" key pointing to a .dlbr file
+            if "path" in entry and "summary" in entry:
+                tensors = DLBAutoSampler.load_relevance_step(entry["path"], device=device)
+                loaded.append(tensors)
+            else:
+                # Already a full {node: tensor} dict (policy="full") — pass through
+                loaded.append(entry)
+
+        return loaded
 
     def _prepare_cache_dir(self, base_dir: Optional[str], policy: str):
         if policy != "disk":

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -93,13 +93,18 @@ class DLBAutoSampler:
         self.tokenizer = tokenizer
 
     def _clear_dlb_memory(self):
-        """Clear DLB intermediate storage (node_io + all_wt) and CUDA cache."""
+        """Clear DLB intermediate storage (node_io + all_wt).
+        
+        Note: torch.cuda.empty_cache() and gc.collect() intentionally NOT called here.
+        empty_cache() releases ALL cached GPU memory back to the OS, forcing CUDA to
+        reallocate everything from scratch on the next predict() call. As tensors grow
+        with sequence length, this reallocation cost grows proportionally — it was the
+        primary cause of predict() time increasing ~0.5s per 50 tokens.
+        Python's reference-counting GC handles the freed dicts immediately.
+        """
         self.dlb.node_io = {}
         if hasattr(self.dlb, 'all_wt'):
             self.dlb.all_wt = {}
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        gc.collect()
 
     def _save_to_disk(
         self,
@@ -820,7 +825,6 @@ class DLBAutoSampler:
 
                 if not return_layerwise_output:
                     del logits, io_data
-                    gc.collect()
 
                 # ── Stage C: Save scores to disk ──
                 _ts = time.perf_counter()

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -918,9 +918,14 @@ class DLBAutoSampler:
 
                 if _use_dlb:
                     # ── SLOW PATH: Full DLB predict (builds node_io for relevance) ──
+                    if _past_kv is not None:
+                        del _past_kv
+                        _past_kv = None
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
                     io_data = self.dlb.predict(generated, attn, debug=False, temperature=1.0)
                     logits = self._extract_last_logits(io_data)
-                    _past_kv = None          # DLB used its own forward → KV-cache is stale
+                    
                 else:
                     # ── FAST PATH: Native model with KV-cache (~10-30 ms/token) ──
                     logits, _past_kv = self._native_forward_with_cache(

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1067,14 +1067,19 @@ class DLBAutoSampler:
                         # for disk policy, so nothing left to free
                     elif cache_policy == "full":
                         # Deep-copy tensors to CPU so we can safely free GPU memory
-                        cpu_rel = {}
-                        for k, v in rel_dict.items():
-                            if torch.is_tensor(v):
-                                cpu_rel[k] = v.detach().cpu().clone()
-                            else:
-                                cpu_rel[k] = v
-                        relevance_trace.append(cpu_rel)
-                        del cpu_rel
+                        full_rel = self._store_relevance_entry(
+                            rel_dict,
+                            policy=cache_policy,
+                            step_idx=_gen_step_idx,
+                            cache_dir=cache_dir_path,
+                            target_dtype=cache_dtype,
+                            move_to_cpu=relevance_move_to_cpu,
+                            use_compression=relevance_use_compression,
+                            compression_method=relevance_compression_method,
+                            pickle_protocol=relevance_pickle_protocol,
+                        )
+                        relevance_trace.append(full_rel)
+                        del full_rel
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -1081,7 +1081,6 @@ class DLBAutoSampler:
                         )
                         relevance_trace.clear()
                         relevance_trace.append(full_rel)
-                        full_rel.clear()
                         del full_rel
                 _t["relevance_save"] = time.perf_counter() - _ts
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -600,9 +600,12 @@ class DLBAutoSampler:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-        if normalized_policy == "summary" or normalized_policy == "full":
+        if normalized_policy == "summary":
             cpu_dict = self._flat_to_dict(flat_cpu, meta_entries)
             return {"summary": self._summarize_relevance(cpu_dict)}
+
+        if normalized_policy == "full":
+            return self._flat_to_dict(flat_cpu, meta_entries)
 
         if normalized_policy != "disk":
             raise ValueError(
@@ -1076,6 +1079,7 @@ class DLBAutoSampler:
                             compression_method=relevance_compression_method,
                             pickle_protocol=relevance_pickle_protocol,
                         )
+                        relevance_trace.clear()
                         relevance_trace.append(full_rel)
                         full_rel.clear()
                         del full_rel

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -109,6 +109,79 @@ class DLBAutoSampler:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
+    # ── Native Forward with KV-Cache (Fast Path) ──────────────────────────
+
+    def _check_native_forward_support(self):
+        """Check if the underlying model supports native forward with KV-cache.
+
+        Walks the wrapper chain (e.g., ModelWrapper.model → AutoModelForCausalLM)
+        looking for a model whose forward() accepts `use_cache` and
+        `past_key_values` parameters.
+        """
+        model = self.dlb.model
+        inner = getattr(model, 'model', None)
+        if inner is None:
+            return False
+        try:
+            import inspect
+            sig = inspect.signature(inner.forward)
+            return 'use_cache' in sig.parameters and 'past_key_values' in sig.parameters
+        except (ValueError, TypeError):
+            return False
+
+    def _native_forward_with_cache(self, input_ids, attention_mask, past_key_values=None):
+        """Fast forward pass using the native model with KV-cache.
+
+        When *past_key_values* is ``None``, runs a full “prefill” pass over the
+        entire sequence.  On subsequent calls with valid *past_key_values*,
+        only processes the **last token** (incremental decode), reusing cached
+        key / value states from all previous positions.
+
+        Parameters
+        ----------
+        input_ids : Tensor [batch, seq_len]
+            Full token sequence (including all previously generated tokens).
+        attention_mask : Tensor [batch, seq_len]
+            Full attention mask covering every position.
+        past_key_values : tuple | None
+            Cached KV states from a previous call, or ``None`` for prefill.
+
+        Returns
+        -------
+        (logits, new_past_key_values)
+            *logits*: ``[batch, 1, vocab]`` for incremental /
+            ``[batch, seq_len, vocab]`` for prefill.
+            *new_past_key_values*: updated cache for the next call.
+        """
+        # Unwrap ModelWrapper → access the HuggingFace CausalLM directly
+        inner_model = self.dlb.model.model
+
+        if past_key_values is not None:
+            # Incremental decode — only feed the LAST token
+            model_input = input_ids[:, -1:]
+        else:
+            # Prefill — feed the entire sequence
+            model_input = input_ids
+
+        with torch.no_grad():
+            output = inner_model(
+                input_ids=model_input,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                use_cache=True,
+            )
+
+        # Extract logits (handles CausalLMOutput, plain Tensor, or tuple)
+        if hasattr(output, 'logits'):
+            logits = output.logits
+        elif isinstance(output, torch.Tensor):
+            logits = output
+        else:
+            logits = output[0]
+
+        new_past_kv = getattr(output, 'past_key_values', None)
+        return logits, new_past_kv
+
     def _save_to_disk(
         self,
         data,
@@ -782,23 +855,42 @@ class DLBAutoSampler:
             else:
                 _should_run_dlb = lambda idx: True
 
+            # ── Fast-path: native model with KV-cache ──
+            _native_fwd_ok = self._check_native_forward_support()
+            _past_kv = None          # KV-cache for native forward
+            if _native_fwd_ok:
+                print("  ⚡ Native KV-cache forward available — fast path enabled for non-DLB steps")
+
             for _gen_step_idx in range(max_new_tokens if max_new_tokens is not None else 10_000_000):
                 _t = {}  # timing dict for this step
                 _t["step"] = _gen_step_idx
                 _t["seq_len"] = generated.shape[1]
 
-                # ── Stage A: Forward pass (predict) ──
+                # ── Stage A: Forward pass ──
                 if device == "cuda":
                     torch.cuda.synchronize()
                 _ts = time.perf_counter()
-                io_data = self.dlb.predict(generated, attn, debug=False, temperature=1.0)
+
+                _use_dlb = _should_run_dlb(_gen_step_idx) or not _native_fwd_ok
+
+                if _use_dlb:
+                    # ── SLOW PATH: Full DLB predict (builds node_io for relevance) ──
+                    io_data = self.dlb.predict(generated, attn, debug=False, temperature=1.0)
+                    logits = self._extract_last_logits(io_data)
+                    _past_kv = None          # DLB used its own forward → KV-cache is stale
+                else:
+                    # ── FAST PATH: Native model with KV-cache (~10-30 ms/token) ──
+                    logits, _past_kv = self._native_forward_with_cache(
+                        generated, attn, past_key_values=_past_kv,
+                    )
+                    io_data = None
+
                 if device == "cuda":
                     torch.cuda.synchronize()
                 _t["predict"] = time.perf_counter() - _ts
 
                 # ── Stage B: Logits extraction + sampling ──
                 _ts = time.perf_counter()
-                logits = self._extract_last_logits(io_data)        # [1, T_cur, V]
                 if logits.device != device:
                     logits = logits.to(device)
                 next_logits = self._as_float(logits[:, -1, :])     # Float for processors
@@ -827,7 +919,9 @@ class DLBAutoSampler:
                 _t["sampling"] = time.perf_counter() - _ts
 
                 if not return_layerwise_output:
-                    del logits, io_data
+                    del logits
+                    if io_data is not None:
+                        del io_data
 
                 # ── Stage C: Save scores to disk ──
                 _ts = time.perf_counter()
@@ -850,7 +944,7 @@ class DLBAutoSampler:
 
                 # ── Stage D: Save IO data to disk ──
                 _ts = time.perf_counter()
-                if return_layerwise_output:
+                if return_layerwise_output and io_data is not None:
                     if disk_streaming:
                         path = self._save_to_disk(
                             io_data,
@@ -907,15 +1001,20 @@ class DLBAutoSampler:
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──
+                # Only needed after DLB predict steps (which populate node_io).
+                # On fast-path steps: nothing to clean, and empty_cache() would
+                # destroy the KV-cache living in GPU memory via _past_kv.
                 _ts = time.perf_counter()
-                self._clear_dlb_memory()
+                if _use_dlb:
+                    self._clear_dlb_memory()
                 _t["cleanup"] = time.perf_counter() - _ts
 
                 _t["total"] = _t["predict"] + _t["sampling"] + _t["scores_save"] + _t["io_save"] + _t["backtrace"] + _t["relevance_save"] + _t["cleanup"]
 
                 # Print per-token line
+                _path_label = "DLB " if _use_dlb else "FAST"
                 print(
-                    f"  ⏱ Token {_gen_step_idx:3d} (seq={_t['seq_len']:4d}) │ "
+                    f"  ⏱ Token {_gen_step_idx:3d} [{_path_label}] (seq={_t['seq_len']:4d}) │ "
                     f"predict={_t['predict']:6.2f}s │ "
                     f"sample={_t['sampling']:5.3f}s │ "
                     f"backtrace={_t['backtrace']:5.2f}s │ "

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -93,19 +93,33 @@ class DLBAutoSampler:
         self.tokenizer = tokenizer
 
     def _clear_dlb_memory(self):
-        """Clear DLB intermediate storage (node_io + all_wt) and defragment CUDA cache.
-        
-        Note: gc.collect() intentionally NOT called here — it forces a full Python GC sweep
-        (~10-50ms) on every step. Python's reference counting handles the freed dicts immediately.
-        
-        torch.cuda.empty_cache() IS called because, as sequence length grows each step, new
-        tensors are slightly larger than old ones. Without defragmenting, the CUDA allocator's
-        cached blocks from previous (smaller) tensors can't serve new (larger) requests,
-        eventually causing OOM around 250 tokens.
-        """
+        """Clear DLB intermediate storage BEFORE the next allocation, not after."""
+        # Explicitly delete tensor contents before dropping the dict reference,
+        # so Python's refcount drops to zero immediately without waiting for GC.
+        node_io = getattr(self.dlb, 'node_io', None)
+        if node_io:
+            for v in node_io.values():
+                if isinstance(v, dict):
+                    for vv in v.values():
+                        if torch.is_tensor(vv):
+                            del vv
+                elif torch.is_tensor(v):
+                    del v
+            node_io.clear()
         self.dlb.node_io = {}
-        if hasattr(self.dlb, 'all_wt'):
-            self.dlb.all_wt = {}
+
+        all_wt = getattr(self.dlb, 'all_wt', None)
+        if all_wt:
+            for v in all_wt.values():
+                if isinstance(v, (list, tuple)):
+                    for vv in v:
+                        if torch.is_tensor(vv):
+                            del vv
+                elif torch.is_tensor(v):
+                    del v
+            all_wt.clear()
+        self.dlb.all_wt = {}
+
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
@@ -917,15 +931,20 @@ class DLBAutoSampler:
                 _use_dlb = _should_run_dlb(_gen_step_idx) or not _native_fwd_ok
 
                 if _use_dlb:
-                    # ── SLOW PATH: Full DLB predict (builds node_io for relevance) ──
+                    # ── SLOW PATH: clear BEFORE allocating ──
+                    # Kill old node_io/all_wt first so peak RAM = 1× not 2×
+                    self._clear_dlb_memory()
                     if _past_kv is not None:
                         del _past_kv
                         _past_kv = None
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
                     io_data = self.dlb.predict(generated, attn, debug=False, temperature=1.0)
                     logits = self._extract_last_logits(io_data)
-                    
+                    # Drop io_data immediately unless layerwise output is needed —
+                    # self.dlb.node_io and io_data are the same dict, so keeping
+                    # io_data alive prevents the refcount from hitting zero
+                    if not return_layerwise_output:
+                        del io_data
+                        io_data = None
                 else:
                     # ── FAST PATH: Native model with KV-cache (~10-30 ms/token) ──
                     logits, _past_kv = self._native_forward_with_cache(
@@ -1050,12 +1069,15 @@ class DLBAutoSampler:
                 _t["relevance_save"] = time.perf_counter() - _ts
 
                 # ── Stage G: Memory cleanup ──
-                # Only needed after DLB predict steps (which populate node_io).
-                # On fast-path steps: nothing to clean, and empty_cache() would
-                # destroy the KV-cache living in GPU memory via _past_kv.
+                # _clear_dlb_memory() is now called PRE-step (before predict),
+                # so there's nothing to clear here after relevance is saved.
+                # We still need to free rel_dict if it wasn't consumed by
+                # _store_relevance_entry (e.g. return_relevance=False).
                 _ts = time.perf_counter()
-                if _use_dlb:
-                    self._clear_dlb_memory()
+                if rel_dict is not None:
+                    rel_dict.clear()
+                    del rel_dict
+                    rel_dict = None
                 _t["cleanup"] = time.perf_counter() - _ts
 
                 _t["total"] = _t["predict"] + _t["sampling"] + _t["scores_save"] + _t["io_save"] + _t["backtrace"] + _t["relevance_save"] + _t["cleanup"]

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -109,7 +109,7 @@ class DLBAutoSampler:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-    # ── Native Forward with KV-Cache (Fast Path) ──────────────────────────
+    # -- Native Forward with KV-Cache (Fast Path) --------------------------
 
     def _check_native_forward_support(self):
         """Check if the underlying model supports native forward with KV-cache.
@@ -129,10 +129,37 @@ class DLBAutoSampler:
         except (ValueError, TypeError):
             return False
 
-    def _native_forward_with_cache(self, input_ids, attention_mask, past_key_values=None):
+    def _ensure_model_on_device(self, target_device):
+        """Move the inner model to *target_device* if it isn't there already.
+
+        DLB's execution engine operates on its own extracted-weight copies, so
+        the original nn.Module may still be on CPU even when generation runs on
+        CUDA.  This one-time move makes the native forward path possible.
+
+        Returns the device the model actually ended up on (may differ from
+        *target_device* if OOM prevented the move).
+        """
+        inner = self.dlb.model.model
+        try:
+            model_device = next(inner.parameters()).device
+        except StopIteration:
+            return target_device
+
+        if str(model_device) == str(target_device):
+            return model_device
+
+        try:
+            inner.to(target_device)
+            return target_device
+        except (RuntimeError, torch.cuda.OutOfMemoryError):
+            # Not enough VRAM to hold both extracted weights AND model params
+            return model_device
+
+    def _native_forward_with_cache(self, input_ids, attention_mask,
+                                    past_key_values=None, target_device=None):
         """Fast forward pass using the native model with KV-cache.
 
-        When *past_key_values* is ``None``, runs a full “prefill” pass over the
+        When *past_key_values* is ``None``, runs a full "prefill" pass over the
         entire sequence.  On subsequent calls with valid *past_key_values*,
         only processes the **last token** (incremental decode), reusing cached
         key / value states from all previous positions.
@@ -145,6 +172,9 @@ class DLBAutoSampler:
             Full attention mask covering every position.
         past_key_values : tuple | None
             Cached KV states from a previous call, or ``None`` for prefill.
+        target_device : str | torch.device | None
+            Device the generation loop is running on.  Used to ensure the
+            model is on the correct device on the first call.
 
         Returns
         -------
@@ -153,20 +183,33 @@ class DLBAutoSampler:
             ``[batch, seq_len, vocab]`` for prefill.
             *new_past_key_values*: updated cache for the next call.
         """
-        # Unwrap ModelWrapper → access the HuggingFace CausalLM directly
         inner_model = self.dlb.model.model
+
+        # ── One-time device alignment ──
+        if not hasattr(self, '_native_fwd_device_ok'):
+            if target_device is not None:
+                self._ensure_model_on_device(target_device)
+            self._native_fwd_device_ok = True
+
+        # Detect model device for input alignment
+        try:
+            _dev = next(inner_model.parameters()).device
+        except StopIteration:
+            _dev = input_ids.device
 
         if past_key_values is not None:
             # Incremental decode — only feed the LAST token
-            model_input = input_ids[:, -1:]
+            model_input = input_ids[:, -1:].to(_dev)
         else:
             # Prefill — feed the entire sequence
-            model_input = input_ids
+            model_input = input_ids.to(_dev)
+
+        mask_input = attention_mask.to(_dev)
 
         with torch.no_grad():
             output = inner_model(
                 input_ids=model_input,
-                attention_mask=attention_mask,
+                attention_mask=mask_input,
                 past_key_values=past_key_values,
                 use_cache=True,
             )
@@ -882,6 +925,7 @@ class DLBAutoSampler:
                     # ── FAST PATH: Native model with KV-cache (~10-30 ms/token) ──
                     logits, _past_kv = self._native_forward_with_cache(
                         generated, attn, past_key_values=_past_kv,
+                        target_device=device,
                     )
                     io_data = None
 

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -238,35 +238,19 @@ class DLBAutoSampler:
         """Save tensor/dict data to disk with optional lz4 compression. Returns the file path."""
         base_path = cache_dir / filename
 
-        # Types that are safe to pickle (primitives + containers)
-        _SAFE_SCALARS = (int, float, bool, str, bytes, type(None))
-
         def _to_cpu_async(obj):
-            """Recursively move tensors to CPU and drop non-serializable objects."""
             if torch.is_tensor(obj):
                 t = obj.detach()
                 return t.to('cpu', non_blocking=True) if t.is_cuda else t
             if isinstance(obj, np.ndarray):
                 return torch.from_numpy(obj)
             if isinstance(obj, dict):
-                return {k: _to_cpu_async(v) for k, v in obj.items()
-                        if _is_serializable(v)}
+                return {k: _to_cpu_async(v) for k, v in obj.items()}
             if isinstance(obj, list):
-                return [_to_cpu_async(v) for v in obj if _is_serializable(v)]
+                return [_to_cpu_async(v) for v in obj]
             if isinstance(obj, tuple):
-                return tuple(_to_cpu_async(v) for v in obj if _is_serializable(v))
-            if isinstance(obj, _SAFE_SCALARS):
-                return obj
-            # Drop anything else (PyCapsule, C-objects, HF cache internals, etc.)
-            return None
-
-        def _is_serializable(obj):
-            """Quick check: is this object (or container of objects) safe to pickle?"""
-            if torch.is_tensor(obj) or isinstance(obj, (np.ndarray, *_SAFE_SCALARS)):
-                return True
-            if isinstance(obj, (dict, list, tuple)):
-                return True
-            return False
+                return tuple(_to_cpu_async(v) for v in obj)
+            return obj
 
         cpu_data = _to_cpu_async(data)
         if torch.cuda.is_available():
@@ -287,7 +271,7 @@ class DLBAutoSampler:
             torch.save(cpu_data, file_path, pickle_protocol=pickle_protocol)
 
         del cpu_data
-        # gc.collect()
+        gc.collect()
         return str(file_path)
 
     def _print_generated_sequence(self, generated: torch.Tensor, prefix: str = ""):
@@ -657,7 +641,7 @@ class DLBAutoSampler:
                 f.write(raw_bytes)
         del raw_bytes
 
-        # gc.collect()
+        gc.collect()
         return {
             "summary": summary_val,
             "path": str(file_path),
@@ -1016,7 +1000,7 @@ class DLBAutoSampler:
                         )
                         io_data_trace.append({"path": path})
                         del io_data
-                        # gc.collect()
+                        gc.collect()
                     else:
                         io_data_trace.append(io_data)
                 _t["io_save"] = time.perf_counter() - _ts

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/dlb_auto_sampler.py
@@ -607,7 +607,7 @@ class DLBAutoSampler:
         return_relevance: bool = False,
         explain_tokens = "all",
         debug: bool = False,
-        relevance_cache_policy: str = "full",
+        relevance_cache_policy: str = "none",
         relevance_cache_dir: Optional[str] = None,
         relevance_compress_dtype: Optional[Any] = "float16",
         relevance_move_to_cpu: bool = True,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/execution_engine_noncache.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/execution_engine_noncache.py
@@ -372,14 +372,9 @@ def setup_consistent_environment(model=None):
     except Exception as e:
         logger.debug(f"⚠️  Could not set deterministic SDPA: {e}")
     
-    # 🔧 ENHANCED: Memory management for consistent performance
-    try:
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.synchronize()
-            logger.debug("✅ CUDA memory cleared and synchronized")
-    except Exception as e:
-        logger.debug(f"⚠️  Could not manage CUDA memory: {e}")
+    # Note: torch.cuda.empty_cache() + synchronize() intentionally removed here.
+    # They force expensive GPU synchronization (~50-100ms) and are unnecessary
+    # during setup — memory cleanup is handled at end of generation steps.
     
     logger.debug("🔧 Deterministic environment setup complete!")
 
@@ -3786,79 +3781,75 @@ def execute_aten_operation(func_name, aten_op, layer_in, layer_hyperparams, meth
         logger.error(f"[Execution Error] Node `{node_name}` failed in `{func_name}`: {e}")
         #return layer_in
 
-def run_execution_nocache(graph, layer_stack, model, extracted_weights, inputs, tracer, exported_program=None):
+def run_execution_nocache(graph, layer_stack, model, extracted_weights, inputs, tracer, exported_program=None, cached_state=None):
     logger = get_logger()
     logger.info(f"Executing `run_execution_nocache` ...!")
     
-    # 🔧 CONSISTENCY FIX: Set up consistent environment
-    setup_consistent_environment(model)
+    # Use cached_state to skip redundant setup on repeated calls (e.g., during generation).
+    # The dict is mutated in-place so the caller (ExecutionEngineNoCache) retains state.
+    if cached_state is None:
+        cached_state = {}
     
-    # 🔧 CRITICAL FIX: Ensure model is in consistent state
-    logger.debug("🔧 Ensuring model consistency...")
-    model.eval()
-    model.requires_grad_(False)
+    # ── Environment setup + model state: only on FIRST call ──
+    if not cached_state.get("env_setup_done"):
+        setup_consistent_environment(model)
+        model.eval()
+        model.requires_grad_(False)
+        cached_state["env_setup_done"] = True
+        logger.debug("✅ Environment setup and model consistency ensured (first call)")
     
-    # 🔧 CRITICAL FIX: Synchronize extracted weights with current model state
-    logger.debug("🔧 Synchronizing extracted weights with model state...")
-    if exported_program is not None:
-        for placeholder_name, extracted_weight in extracted_weights.items():
-            if extracted_weight is not None and isinstance(extracted_weight, torch.Tensor):
-                # Get the real parameter name from exported_program
-                real_key = None
-                for spec in exported_program.graph_signature.input_specs:
-                    if hasattr(spec.arg, 'name') and spec.arg.name == placeholder_name:
-                        real_key = spec.target
-                        break
-                
-                if real_key and real_key in model.state_dict():
-                    current_weight = model.state_dict()[real_key]
-                    # Reference weight directly — read-only during forward pass
-                    extracted_weights[placeholder_name] = current_weight
-                    logger.debug(f"✅ Synchronized {placeholder_name} -> {real_key}")
-    else:
-        logger.warning("⚠️ No exported_program provided, skipping weight synchronization")
+    # ── Weight synchronization: only on FIRST call ──
+    # Weights don't change during generation (model is in eval mode with requires_grad=False).
+    # Previously this called model.state_dict() TWICE per placeholder on EVERY call — for a
+    # large model that's hundreds of MB of allocation per predict() invocation.
+    if not cached_state.get("weights_synced"):
+        logger.debug("🔧 Synchronizing extracted weights with model state...")
+        if exported_program is not None:
+            # Build placeholder→target mapping once (avoids repeated inner loop)
+            spec_map = {}
+            for spec in exported_program.graph_signature.input_specs:
+                if hasattr(spec.arg, 'name'):
+                    spec_map[spec.arg.name] = spec.target
+            
+            # Single call to model.state_dict() instead of N calls (one per placeholder)
+            state_dict = model.state_dict()
+            for placeholder_name, extracted_weight in extracted_weights.items():
+                if extracted_weight is not None and isinstance(extracted_weight, torch.Tensor):
+                    real_key = spec_map.get(placeholder_name)
+                    if real_key and real_key in state_dict:
+                        extracted_weights[placeholder_name] = state_dict[real_key]
+                        logger.debug(f"✅ Synchronized {placeholder_name} -> {real_key}")
+            del state_dict  # Free the full state dict copy immediately
+        else:
+            logger.warning("⚠️ No exported_program provided, skipping weight synchronization")
+        cached_state["weights_synced"] = True
+        logger.debug("✅ Weight synchronization complete")
     
-    logger.debug("✅ Weight synchronization complete")
+    # ── Model metadata: use pre-computed values from cached_state ──
+    target_device = cached_state.get("target_device")
+    if target_device is None:
+        target_device = ensure_model_has_device_attribute(model)
+        cached_state["target_device"] = target_device
     
-    # 🔧 CRITICAL FIX: Preserve original model precision instead of forcing float32
-    # This ensures numerical consistency with the original model
-    logger.debug("Preserving original model precision for consistency")
-    for param in model.parameters():
-        logger.debug(f"Parameter {param.shape} dtype: {param.dtype}")
-    
-    for buffer in model.buffers():
-        logger.debug(f"Buffer {buffer.shape} dtype: {buffer.dtype}")
-    
-    logger.debug("✅ Model consistency ensured")
-    
-    # 🔧 ENHANCED FIX: Get the target device from the model for all operations
-    target_device = ensure_model_has_device_attribute(model)
-    logger.debug(f"🎯 Target device for all operations: {target_device}")
-    
-    # 🔧 ENHANCED FIX: Get the model dtype for all operations
-    model_dtype = torch.float32  # fallback
-    for param in model.parameters():
-        if param.is_floating_point():
-            model_dtype = param.dtype
-            break
-    else:
-        for buffer in model.buffers():
-            if buffer.is_floating_point():
-                model_dtype = buffer.dtype
-                break
-    logger.debug(f"🎯 Model dtype for all operations: {model_dtype}")
+    model_dtype = cached_state.get("model_dtype", torch.float32)
     
     tensor_map = {}
     node_io = {}
 
-    model_signature = inspect.signature(model.forward)
-    all_param_names = list(model_signature.parameters.keys())
+    # Use pre-computed signature info from cached_state (avoids inspect.signature on every call)
+    all_param_names = cached_state.get("all_param_names")
+    required_params = cached_state.get("required_params")
     
-    required_params = [
-        name for name, param in model_signature.parameters.items()
-        if param.default is inspect.Parameter.empty 
-        and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
-    ]
+    if all_param_names is None:
+        model_signature = inspect.signature(model.forward)
+        all_param_names = list(model_signature.parameters.keys())
+        required_params = [
+            name for name, param in model_signature.parameters.items()
+            if param.default is inspect.Parameter.empty 
+            and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        ]
+        cached_state["all_param_names"] = all_param_names
+        cached_state["required_params"] = required_params
     
     if len(inputs) < len(required_params):
         raise ValueError(
@@ -4174,9 +4165,37 @@ class ExecutionEngineNoCache:
         self.debug = debug
         self.log_level = log_level
         
-        # Setup logging for this instance with force_reconfigure to ensure proper setup
+        # Setup logging for this instance
         self.logger = setup_logging(debug=debug, log_level=log_level, force_reconfigure=True)
         self.logger.info(f"ExecutionEngineNoCache initialized with debug={debug}, log_level={log_level}")
+        
+        # Pre-compute model metadata that is invariant across calls.
+        # This avoids re-running inspect.signature(), iterating all parameters for dtype,
+        # and calling ensure_model_has_device_attribute() on every predict() call.
+        self._cached_state = {
+            "env_setup_done": False,
+            "weights_synced": False,
+            "target_device": ensure_model_has_device_attribute(model),
+            "model_dtype": self._detect_model_dtype(),
+        }
+        # Pre-compute model forward signature (avoids inspect.signature on every call)
+        model_signature = inspect.signature(model.forward)
+        self._cached_state["all_param_names"] = list(model_signature.parameters.keys())
+        self._cached_state["required_params"] = [
+            name for name, param in model_signature.parameters.items()
+            if param.default is inspect.Parameter.empty
+            and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        ]
+
+    def _detect_model_dtype(self):
+        """Detect model's computation dtype from its parameters/buffers (called once at init)."""
+        for param in self.model.parameters():
+            if param.is_floating_point():
+                return param.dtype
+        for buffer in self.model.buffers():
+            if buffer.is_floating_point():
+                return buffer.dtype
+        return torch.float32
 
     def run(self, inputs, debug=None, log_level=None):
         """Run the execution engine with optional debug and log level overrides"""
@@ -4194,7 +4213,7 @@ class ExecutionEngineNoCache:
             
         self.logger.info(f"Starting execution with {len(inputs)} inputs")
         
-        # Run the execution
+        # Run the execution with cached_state to avoid redundant setup on repeated calls
         result = run_execution_nocache(
             graph=self.graph,
             layer_stack=self.layer_stack,
@@ -4203,6 +4222,7 @@ class ExecutionEngineNoCache:
             inputs=inputs,
             tracer=self.tracer,
             exported_program=self.exported_program,
+            cached_state=self._cached_state,
         )
         
         # Flush logs at the end of execution to ensure all debug statements are captured

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/core/execution_engine_noncache.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/core/execution_engine_noncache.py
@@ -3900,6 +3900,14 @@ def run_execution_nocache(graph, layer_stack, model, extracted_weights, inputs, 
             else:
                 tensor_map[layer_stack[len(extracted_weights)]] = inputs
 
+    # ── Eager tensor_map cleanup: pre-compute reference counts ──
+    # Track how many children still need each node's output from tensor_map.
+    # When the count reaches 0, we delete the entry from tensor_map to free GPU memory.
+    _remaining_children = {}
+    for _n in layer_stack:
+        _ch = graph.nodes[_n].get("children", [])
+        _remaining_children[_n] = len(_ch)
+
     for node_name in layer_stack:
         node_data = graph.nodes[node_name]
         parents = node_data["parents"]
@@ -4149,7 +4157,19 @@ def run_execution_nocache(graph, layer_stack, model, extracted_weights, inputs, 
             "layer_hyperparams":layer_hyperparams,
         }
 
+        # ── Eager tensor_map cleanup ──
+        # Decrement reference counts for parents. When a parent's count reaches 0,
+        # all downstream consumers have been processed and the tensor can be freed
+        # from tensor_map. The tensor survives in node_io["output_values"] for
+        # relevance propagation.
+        for p in parents:
+            if p in _remaining_children:
+                _remaining_children[p] -= 1
+                if _remaining_children[p] <= 0 and p in tensor_map:
+                    del tensor_map[p]
+
     # Free tensor_map — node_io already holds all tensor references
+    tensor_map.clear()
     del tensor_map
 
     return node_io

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -387,17 +387,21 @@ class DLBacktrace:
             print(f"   Execution engine: Non-cache (ExecutionEngineNoCache)")
             print(f"   Layer stack length: {len(self.layer_stack)}")
         
-        # Always use non-cache execution engine
-        executor = ExecutionEngineNoCache(
-            model=self.model,
-            extracted_weights=self.extracted_weights,
-            fx_graph=self.graph,
-            layer_stack=self.layer_stack,
-            tracer=self.tracer,
-            exported_program=self.exported_program,
-            debug=debug,
-            log_level="DEBUG" if debug else "INFO"
-        )
+        # Reuse cached executor to avoid re-creating on every predict() call.
+        # The executor's _cached_state dict persists across calls, skipping redundant
+        # environment setup, weight synchronization, and metadata detection.
+        if not hasattr(self, '_cached_executor') or self._cached_executor is None:
+            self._cached_executor = ExecutionEngineNoCache(
+                model=self.model,
+                extracted_weights=self.extracted_weights,
+                fx_graph=self.graph,
+                layer_stack=self.layer_stack,
+                tracer=self.tracer,
+                exported_program=self.exported_program,
+                debug=debug,
+                log_level="DEBUG" if debug else "INFO"
+            )
+        executor = self._cached_executor
         
         if debug:
             print(f"🔧 Starting execution with {type(executor).__name__}")
@@ -548,7 +552,7 @@ class DLBacktrace:
         return_scores=False,
         return_relevance=False,
         return_layerwise_output=False,
-        relevance_cache_policy="full",
+        relevance_cache_policy="none",
         relevance_cache_dir=None,
         relevance_compress_dtype="float16",
         relevance_move_to_cpu=True,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -1043,11 +1043,6 @@ class DLBacktrace:
         eng = DLBAutoSampler(self, tokenizer)  # `self` is the DLB engine (has .model and .predict)
         return eng.generate(input_ids=input_ids, attention_mask=attention_mask, **kwargs) 
 
-    def load_relevance_trace(self, relevance_trace: list, device: str = "cpu") -> list:
-        """Load disk-cached relevance stubs back into tensor dicts for visualization."""
-        from .core.dlb_auto_sampler import DLBAutoSampler
-        return DLBAutoSampler.load_relevance_trace(relevance_trace, device=device)
-
     def print_all_relevance_info(self):
         """ 
             print shape and sum of all relevance values in `self.all_wt`.

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -552,7 +552,7 @@ class DLBacktrace:
         return_scores=False,
         return_relevance=False,
         return_layerwise_output=False,
-        relevance_cache_policy="none",
+        relevance_cache_policy="full",
         relevance_cache_dir=None,
         relevance_compress_dtype="float16",
         relevance_move_to_cpu=True,
@@ -698,6 +698,11 @@ class DLBacktrace:
             if debug:
                 print(f"🚀 Running generation task with sample_auto...")
             
+            # When user requests relevance but hasn't set a storage policy,
+            # upgrade from the default "none" to "full" (in-memory).
+            if return_relevance and relevance_cache_policy == "none":
+                relevance_cache_policy = "full"
+
             cache_kwargs = {
                 "relevance_cache_policy": relevance_cache_policy,
                 "relevance_cache_dir": relevance_cache_dir,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -553,7 +553,7 @@ class DLBacktrace:
         return_relevance=False,
         return_layerwise_output=False,
         relevance_cache_policy="full",
-        relevance_cache_dir=None,
+        relevance_cache_dir="./relevance_cache",
         relevance_compress_dtype="float16",
         relevance_move_to_cpu=True,
         debug=False,

--- a/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
+++ b/dl_backtrace/pytorch_backtrace/dlbacktrace/dlbacktrace.py
@@ -1043,6 +1043,11 @@ class DLBacktrace:
         eng = DLBAutoSampler(self, tokenizer)  # `self` is the DLB engine (has .model and .predict)
         return eng.generate(input_ids=input_ids, attention_mask=attention_mask, **kwargs) 
 
+    def load_relevance_trace(self, relevance_trace: list, device: str = "cpu") -> list:
+        """Load disk-cached relevance stubs back into tensor dicts for visualization."""
+        from .core.dlb_auto_sampler import DLBAutoSampler
+        return DLBAutoSampler.load_relevance_trace(relevance_trace, device=device)
+
     def print_all_relevance_info(self):
         """ 
             print shape and sum of all relevance values in `self.all_wt`.


### PR DESCRIPTION
- _check_native_forward_support() inspects the model wrapper chain for HuggingFace use_cache + past_key_values support
- _native_forward_with_cache() runs native model forward with KV-cache. Handles both prefill (full sequence, first call) and incremental decode (single token, subsequent calls)
- Stage A: Dual dispatch _should_run_dlb(step) → DLB predict or fast path with KV-cache
- KV-cache invalidated after DLB steps (DLB uses its own forward)
- Stage G cleanup skipped on fast-path steps ( destroy KV-cache via empty_cache())
- Per-token timing now shows [DLB ] or [FAST] label